### PR TITLE
removed unknownCommand error

### DIFF
--- a/src/bot.ts
+++ b/src/bot.ts
@@ -19,7 +19,9 @@ const botOwners = yaml.load(fs.readFileSync('config/owners.yml', 'utf8')) as str
 const client = new Commando.Client({ owner: botOwners, commandPrefix: BOT_PREFIX });
 // register command groups
 client.registry
-  .registerDefaults()
+  .registerDefaultTypes()
+  .registerDefaultGroups()
+  .registerDefaultCommands({ unknownCommand: false })
   .registerGroups([
     ['suggestions', 'Suggestions'],
     ['interviews', 'Mock Interviews']


### PR DESCRIPTION
# Related Issues
Resolves https://github.com/uwcsc/codeybot/issues/27

# Summary of Changes 
unpacked registerDefaults and split it into its three innate types, group, and default commands registers.
Disabled registry of default unknown command.

# Steps to Reproduce
type any wrong command (.asopdiusaidouasipod for example), bot gives no reply.
