### PR TITLE
Created dockerfile for production environment

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,1 +1,2 @@
 node_modules
+.env

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,6 @@ WORKDIR /usr/app
 
 # Install app dependencies
 COPY package.json .
-COPY yarn.lock .
 RUN npm install
 
 # Copy app files

--- a/Dockerfile.prod
+++ b/Dockerfile.prod
@@ -1,0 +1,19 @@
+# Stage 1: Typescript build app
+FROM node:16-alpine AS ts-build
+WORKDIR /usr/app
+COPY package.json .
+RUN npm install
+COPY . .
+RUN npm run ts:build
+
+# Stage 2: Run in production env
+FROM node:16-alpine
+WORKDIR /usr/app
+ENV NODE_ENV="prod"
+COPY package.json .
+RUN npm install --only=production
+RUN npm install pm2 -g
+COPY . .
+COPY --from=ts-build /usr/app/dist ./dist
+
+CMD [ "pm2-runtime", "--raw", "./dist/index.js" ]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,6 +2,8 @@ services:
   codey-bot:
     image: codey:latest
     container_name: codey-bot
+    env_file:
+      - .env
     environment:
       - CHOKIDAR_USEPOLLING=true
     volumes:

--- a/src/components/db.ts
+++ b/src/components/db.ts
@@ -3,6 +3,7 @@ import { open, Database } from 'sqlite';
 
 import { initSuggestionsTable } from './suggestions';
 import { initInterviewTables } from './interview';
+import logger from './logger';
 
 let db: Database | null = null;
 
@@ -22,7 +23,7 @@ export const openDB = async (): Promise<Database> => {
       driver: sqlite3.Database
     });
     await initTables(db);
-    console.log('Initialized database and tables.');
+    logger.info('Initialized database and tables.');
   }
   return db;
 };

--- a/src/components/logger.ts
+++ b/src/components/logger.ts
@@ -1,6 +1,10 @@
 import * as winston from 'winston';
 import 'winston-daily-rotate-file';
 
+const consoleTransport = new winston.transports.Console({
+  format: process.env.NODE_ENV === 'dev' ? winston.format.prettyPrint() : undefined
+});
+
 const dailyRotateTransport = new winston.transports.DailyRotateFile({
   filename: '%DATE%.log',
   dirname: 'logs',
@@ -19,16 +23,8 @@ const logger = winston.createLogger({
     winston.format.timestamp(),
     winston.format.printf(({ level, message, timestamp }) => `[${timestamp}] ${level}: ${JSON.stringify(message)}`)
   ),
-  transports: [dailyRotateTransport, dailyRotateErrorTransport]
+  transports: [consoleTransport, dailyRotateTransport, dailyRotateErrorTransport]
 });
-
-if (process.env.NODE_ENV === 'dev') {
-  logger.add(
-    new winston.transports.Console({
-      format: winston.format.prettyPrint()
-    })
-  );
-}
 
 export const logError = (err: Error, event = 'client', data: { [key: string]: string } = {}): void => {
   logger.error({


### PR DESCRIPTION
# Related Issues
resolves #25
resolves #8 

# Summary of Changes 
Added a dockerfile for production environment, which uses the `pm2` runtime to run the bot instead of `node`. The production image is also leaner than the dev image.

# Steps to Reproduce
Building production image: `docker build . -f Dockerfile.prod -t codey-prod`
Running production container: `docker run -d --env-file .env -v $PWD/logs:/usr/app/logs -v $PWD/db:/usr/app/db codey-prod`
