### PR TITLE
sorted domains for both codebase and for output

### DIFF
--- a/src/components/interview.ts
+++ b/src/components/interview.ts
@@ -5,16 +5,16 @@ import { openDB } from './db';
 
 //maps from key to readable string
 export const availableDomains: { [key: string]: string } = {
-  frontend: 'Frontend',
   backend: 'Backend',
-  design: 'Design',
-  pm: 'PM',
   datasci: 'DataSci',
+  design: 'Design',
+  frontend: 'Frontend',
+  gamedev: 'GameDev',
+  hardware: 'Hardware',
   infra: 'Infra',
   mobile: 'Mobile',
-  research: 'Research',
-  hardware: 'Hardware',
-  gamedev: 'GameDev'
+  pm: 'PM',
+  research: 'Research'
 };
 
 export interface Interviewer {
@@ -35,7 +35,7 @@ export const getInterviewer = async (id: string): Promise<Interviewer | undefine
 
 export const getDomainsString = (domains: string[]): string => `\`${_.join(domains, '`, `')}\``;
 
-export const getAvailableDomainsString = (): string => getDomainsString(Object.keys(availableDomains));
+export const getAvailableDomainsString = (): string => getDomainsString(Object.keys(availableDomains).sort());
 
 export const parseLink = (link: string): string | null => {
   //checks if link is (roughly) one from calendly or x.ai


### PR DESCRIPTION
# Related Issues
Followup to https://github.com/uwcsc/codeybot/pull/42

# Summary of Changes 
Sorted domains in codebase by alphabetical order.
Domain outputs are sorted by alphabetical order in messages.

# Steps to Reproduce
.interviewerdomain lol
![image](https://user-images.githubusercontent.com/39033120/125212946-96e0be80-e27e-11eb-95e7-db19aebaf63c.png)

