### PR TITLE
added cneryx to owners.yml

### DIFF
--- a/config/owners.yml
+++ b/config/owners.yml
@@ -2,3 +2,4 @@
 - '302921509763022889' # Picowchew#1559 (Picowchew The Panda)
 - '688101791656575077' # fishyfishyfish#4962 (Mark Chen)
 - '255088818309300235' # ǝʞıɹʇSǝldıɹ⊥#9999 (Alex Zhang)
+- '297185799584350208' # u rod#0019 (Chris Xie)


### PR DESCRIPTION
# Related Issues
N/A

# Summary of Changes 
Added cneryx's discord username to owners.yml

# Steps to Reproduce
Add "- '297185799584350208' # u rod#0019 (Chris Xie)" to config/owners.yml
