### PR TITLE
initialized user coin and user coin bonus tables

### DIFF
--- a/src/components/coin.ts
+++ b/src/components/coin.ts
@@ -1,0 +1,26 @@
+import { Database } from 'sqlite';
+
+export const initUserCoinTable = async (db: Database): Promise<void> => {
+  await db.run(
+    `
+    CREATE TABLE IF NOT EXISTS user_coin (
+      user_id VARCHAR(255) PRIMARY KEY NOT NULL,
+      balance INTEGER NOT NULL CHECK(balance>=0),
+      updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+    );
+    `
+  );
+};
+
+export const initUserCoinBonusTable = async (db: Database): Promise<void> => {
+  await db.run(
+    `
+    CREATE TABLE IF NOT EXISTS user_coin_bonus (
+      user_id VARCHAR(255) NOT NULL,
+      bonus_type INTEGER NOT NULL,
+      last_granted TIMESTAMP,
+      PRIMARY KEY (user_id, bonus_type)
+    );
+    `
+  );
+};

--- a/src/components/db.ts
+++ b/src/components/db.ts
@@ -3,6 +3,7 @@ import { open, Database } from 'sqlite';
 
 import { initSuggestionsTable } from './suggestions';
 import { initInterviewTables } from './interview';
+import { initUserCoinBonusTable, initUserCoinTable } from './coin';
 import logger from './logger';
 
 let db: Database | null = null;
@@ -14,6 +15,8 @@ const initTables = async (db: Database): Promise<void> => {
   //initialize all relevant tables
   await initSuggestionsTable(db);
   await initInterviewTables(db);
+  await initUserCoinTable(db);
+  await initUserCoinBonusTable(db);
 };
 
 export const openDB = async (): Promise<Database> => {


### PR DESCRIPTION
# Related Issues
resolves #85 

# Summary of Changes 
Initializes `user_coin` and `user_coin_bonus` tables when bot starts. Omitted `count` and `total_amount` columns in user_coin because we are using a separate transaction/event table for metrics/analytics.

# Steps to Reproduce
Start the bot, run a command to initialize the DB, then run sqlite3 against the db file to run some SQL commands.
## Normal workflow
<img width="715" alt="Screen Shot 2021-10-14 at 9 33 37 PM" src="https://user-images.githubusercontent.com/26018804/137418168-dda9059b-d746-4074-a3b9-aa1f83a95d60.png">

## Testing non-negative constrain
<img width="560" alt="Screen Shot 2021-10-14 at 9 34 07 PM" src="https://user-images.githubusercontent.com/26018804/137418206-86304605-3ff4-4b26-b26a-76a4a519c74c.png">
t
