### PR TITLE
Added interviewer-pause and interviewer-resume

### DIFF
--- a/src/commands/interviews/interviewerClear.ts
+++ b/src/commands/interviews/interviewerClear.ts
@@ -19,14 +19,14 @@ class InterviewerClearCommand extends BaseCommand {
 
     // check if user signed up to be interviewer
     if (!(await getInterviewer(id))) {
-      return await message.reply(
+      return message.reply(
         `you don't seem to have signed up yet, please sign up using \`${this.client.commandPrefix}interviewer-signup <calendarUrl>\`!`
       );
     }
 
     // clear interviewer data
     await clearProfile(id);
-    return await message.reply('your interviewer profile has been cleared!');
+    return message.reply('your interviewer profile has been cleared!');
   }
 }
 

--- a/src/commands/interviews/interviewerDomain.ts
+++ b/src/commands/interviews/interviewerDomain.ts
@@ -30,7 +30,7 @@ class InterviewerDomainCommand extends BaseCommand {
 
     // check if user signed up to be interviewer
     if (!(await getInterviewer(id))) {
-      return await message.reply(
+      return message.reply(
         `you don't seem to have signed up yet, please sign up using \`${this.client.commandPrefix}interviewer-signup <calendarUrl>\`!`
       );
     }

--- a/src/commands/interviews/interviewerPause.ts
+++ b/src/commands/interviews/interviewerPause.ts
@@ -9,7 +9,7 @@ class InterviewerPauseCommand extends BaseCommand {
       name: 'interviewer-pause',
       group: 'interviews',
       memberName: 'pause',
-      description: 'Pauses your interviewer profile.',
+      description: `Pauses your interviewer profile. You will not appear in interviewer queries anymore, until you run \`${client.commandPrefix}interviewer-resume\`.`,
       examples: [`${client.commandPrefix}interviewer-pause`]
     });
   }
@@ -19,14 +19,16 @@ class InterviewerPauseCommand extends BaseCommand {
 
     // check if user signed up to be interviewer
     if (!(await getInterviewer(id))) {
-      return await message.reply(
+      return message.reply(
         `you don't seem to have signed up yet, please sign up using \`${this.client.commandPrefix}interviewer-signup <calendarUrl>\`!`
       );
     }
 
     // pause interviewer data
     await pauseProfile(id);
-    return await message.reply('your interviewer profile has been paused!');
+    return message.reply(
+      `your interviewer profile has been paused! You will not appear in interviewer queries anymore, until you run \`${this.client.commandPrefix}interviewer-resume\`.`
+    );
   }
 }
 

--- a/src/commands/interviews/interviewerProfile.ts
+++ b/src/commands/interviews/interviewerProfile.ts
@@ -23,7 +23,7 @@ class InterviewerProfileCommand extends BaseCommand {
     // check if user signed up to be interviewer
     const interviewer = await getInterviewer(id);
     if (!interviewer) {
-      return await message.reply(
+      return message.reply(
         `you don't seem to have signed up yet, please sign up using \`${this.client.commandPrefix}interviewer-signup <calendarUrl>\`!`
       );
     }

--- a/src/commands/interviews/interviewerResume.ts
+++ b/src/commands/interviews/interviewerResume.ts
@@ -9,7 +9,7 @@ class InterviewerResumeCommand extends BaseCommand {
       name: 'interviewer-resume',
       group: 'interviews',
       memberName: 'resume',
-      description: 'Resumes your interviewer profile.',
+      description: 'Resumes your interviewer profile. You will appear in interviewer queries again.',
       examples: [`${client.commandPrefix}interviewer-resume`]
     });
   }
@@ -19,14 +19,14 @@ class InterviewerResumeCommand extends BaseCommand {
 
     // check if user signed up to be interviewer
     if (!(await getInterviewer(id))) {
-      return await message.reply(
+      return message.reply(
         `you don't seem to have signed up yet, please sign up using \`${this.client.commandPrefix}interviewer-signup <calendarUrl>\`!`
       );
     }
 
     // resume interviewer data
     await resumeProfile(id);
-    return await message.reply('your interviewer profile has been resumed!');
+    return message.reply('your interviewer profile has been resumed!');
   }
 }
 


### PR DESCRIPTION
# Related Issues
Resolves #26 

# Summary of Changes 
- Added the `.interviewer-pause` and `.interviewer-resume` commands to pause/resume an interviewer's profile, respectively
- `.interviewer-clear` now gives an error message instead of a success message if the interviewer has not yet signed up
- Changed the error message of an interviewer who has not yet signed up to use the client's command prefix, instead of a hard coded `.`

# Steps to Reproduce
- Execute the SQL command `ALTER TABLE interviewers ADD COLUMN status INTEGER NOT NULL DEFAULT 0`
- Run `.interviewer-pause` and `.interviewer-resume`
