### PR TITLE
Mention interviewers in interviewer list

### DIFF
--- a/src/commands/interviews/interviewers.ts
+++ b/src/commands/interviews/interviewers.ts
@@ -40,7 +40,8 @@ class InterviewersCommand extends BaseCommand {
   }
 
   private async getInterviewerDisplayInfo(interviewer: Interviewer) {
-    return `${await this.client.users.fetch(interviewer['user_id'])} | [Calendar](${interviewer['link']})\n\n`;
+    const user = await this.client.users.fetch(interviewer['user_id']);
+    return `${user} | [Calendar](${interviewer['link']})\n\n`;
   }
 
   async onRun(message: CommandoMessage, args: { domain: string }): Promise<Message> {

--- a/src/commands/interviews/interviewers.ts
+++ b/src/commands/interviews/interviewers.ts
@@ -40,8 +40,7 @@ class InterviewersCommand extends BaseCommand {
   }
 
   private async getInterviewerDisplayInfo(interviewer: Interviewer) {
-    const userTag = (await this.client.users.fetch(interviewer['user_id'])).tag;
-    return '**' + userTag + '** | [Calendar](' + interviewer['link'] + ')\n\n';
+    return `${await this.client.users.fetch(interviewer['user_id'])} | [Calendar](${interviewer['link']})\n\n`;
   }
 
   async onRun(message: CommandoMessage, args: { domain: string }): Promise<Message> {


### PR DESCRIPTION
# Related Issues
Resolves #108 

# Summary of Changes 
Mention the interviewers in the interviewer list instead of displaying their user tags

# Steps to Reproduce
Run `.int`
