### PR TITLE
Enhanced help command

### DIFF
--- a/src/utils/commands.ts
+++ b/src/utils/commands.ts
@@ -4,6 +4,10 @@ import logger, { logError } from '../components/logger';
 
 export abstract class BaseCommand extends Commando.Command {
   constructor(client: CommandoClient, info: CommandInfo) {
+    info.autoAliases = false;
+    if (info.examples) {
+      info.examples = info.examples.map((ex) => `\`${ex}\``);
+    }
     super(client, info);
   }
 


### PR DESCRIPTION
# Related Issues
Resolves #111 

# Summary of Changes 
- Aliases do not repeat anymore
- Examples are now in inline code blocks

# Steps to Reproduce
Invoke the help command for any command, for example, `.help int`