### PR TITLE
Fix admin commands in DMs

### DIFF
--- a/src/utils/commands.ts
+++ b/src/utils/commands.ts
@@ -47,7 +47,7 @@ export abstract class AdminCommand extends BaseCommand {
     super(client, {
       ...info,
       userPermissions: [...(info.userPermissions || []), 'ADMINISTRATOR'],
-      guildOnly: true // if this was set to false, users can issue Admin comands through DMs with Codey
+      guildOnly: true // if this was set to false, users can issue Admin commands through DMs with Codey
     });
   }
 }

--- a/src/utils/commands.ts
+++ b/src/utils/commands.ts
@@ -46,7 +46,8 @@ export abstract class AdminCommand extends BaseCommand {
   constructor(client: CommandoClient, info: CommandInfo) {
     super(client, {
       ...info,
-      userPermissions: [...(info.userPermissions || []), 'ADMINISTRATOR']
+      userPermissions: [...(info.userPermissions || []), 'ADMINISTRATOR'],
+      guildOnly: true // if this was set to false, users can issue Admin comands through DMs with Codey
     });
   }
 }


### PR DESCRIPTION
# Related Issues
N/A

# Summary of Changes 
Currently, admin commands only check if the user has admin privileges in the channel that the command is issued in. This means that users have full access to admin commands in DM channels.

# Steps to Reproduce
Do `.help` in DMs with Codey and you shouldn't see any admin commands.