### PR TITLE
Added mcpenguin to owners.yml

### DIFF
--- a/config/owners.yml
+++ b/config/owners.yml
@@ -6,3 +6,4 @@
 - '750744296684126289' # elaine#2156 (Elaine Han)
 - '220283093804646400' # android#0456 (Andrew Wang)
 - '183383084538789888' # SurgeonInASuit#1579 (Edwin Yang)
+- '522588708931764243' # mcpenguin#6194 (Marcus Chan)


### PR DESCRIPTION
# Related Issues
N/A

# Summary of Changes 
Added mcpenguin (my Discord username) to `owners.yml`, as outlined in the [Onboarding First Task](https://github.com/uwcsc/codeybot/wiki/Onboarding:-First-Task) page.

# Steps to Reproduce
See the respective page for details.
