### PR TITLE
Changed coin activity bonus cooldown to 5 mins

### DIFF
--- a/src/commands/coin/coinInfo.ts
+++ b/src/commands/coin/coinInfo.ts
@@ -18,7 +18,7 @@ class CoinInfo extends BaseCommand {
     .setColor(EMBED_COLOUR)
     .setTitle('🪙   About Codey Coin   🪙')
     .setThumbnail('https://emojipedia-us.s3.dualstack.us-west-1.amazonaws.com/thumbs/240/twitter/282/coin_1fa99.png') // Thumbnail, if needed?
-    .setDescription(`Codey Coin are rewarded for being active in CSC's events and discord!`)
+    .setDescription(`Codey coins are rewarded for being active in CSC's events and discord!`)
     .addFields(
       {
         name: '🪙   How Can I Obtain Codey Coins?',
@@ -26,7 +26,7 @@ class CoinInfo extends BaseCommand {
           • Participating in CSC events
           • Being active on Discord
           ---Daily bonus - your first message of the day on CSC's Discord will grant some Codey coins
-          ---Activity bonus - your first message of every minute on CSC's Discord will grant some Codey coins`
+          ---Activity bonus - your first message of every 5 minutes on CSC's Discord will grant some Codey coins`
       },
       {
         name: '🪙   What Can I Do With Codey Coins?',

--- a/src/components/coin.ts
+++ b/src/components/coin.ts
@@ -37,7 +37,7 @@ export const coinBonusMap = new Map<BonusType, Bonus>([
       type: BonusType.Daily,
       event: UserCoinEvent.BonusDaily,
       amount: 50,
-      cooldown: 86400000, // one day in milliseconds
+      cooldown: 24 * 60 * 60 * 1000, // one day in milliseconds
       isMessageBonus: true
     }
   ],
@@ -47,7 +47,7 @@ export const coinBonusMap = new Map<BonusType, Bonus>([
       type: BonusType.Activity,
       event: UserCoinEvent.BonusActivity,
       amount: 1,
-      cooldown: 60000, // one minute in milliseconds
+      cooldown: 5 * 60 * 1000, // 5 minutes in milliseconds
       isMessageBonus: true
     }
   ],


### PR DESCRIPTION
# Related Issues
N/A

# Summary of Changes 
- changed coin activity bonus to 5 mins
- related changes in coin info embed

# Steps to Reproduce
- run `.coininfo`
- send messages within 5 mins
