### PR TITLE
Modified message listener so bot ignores its own messages

### DIFF
--- a/src/components/messageListener.ts
+++ b/src/components/messageListener.ts
@@ -1,4 +1,4 @@
-import { Message, TextChannel, DMChannel } from 'discord.js';
+import { Message, DMChannel } from 'discord.js';
 import { applyBonusByUserId } from './coin';
 import { client } from '../bot';
 import { logError } from './logger';
@@ -53,16 +53,21 @@ const punishSpammersAndTrolls = async (message: Message): Promise<boolean> => {
 };
 
 export const messageListener = async (message: Message): Promise<void> => {
-  if (await punishSpammersAndTrolls(message)) {
-    return;
-  }
-
   if (!client.user) {
     return;
   }
 
-  // Ignore all messages created by the bot and dms from users
-  if (message.author.id != client.user.id && message.channel instanceof TextChannel) {
+  // Ignore all messages created by the bot itself
+  if (message.author.id === client.user.id) {
+    return;
+  }
+
+  if (await punishSpammersAndTrolls(message)) {
+    return;
+  }
+
+  // Ignore DMs; include channels of type TextChannel (regular text channel) and NewsChannel (announcements channel)
+  if (!(message.channel instanceof DMChannel)) {
     await applyBonusByUserId(message.author.id);
   }
 };


### PR DESCRIPTION
# Related Issues
N/A

# Summary of Changes 
- Modified the message listener so Codey always ignores its own messages; this would allow Codey to send a message in the honeypot channel without getting its own message deleted (and also help prevent infinite loops in general)
- Also allow a user to receive a coin bonus if their message is sent in the announcements channel

# Steps to Reproduce
One way to test this is to make sure Codey's coin balance does not go up after sending messages