### PR TITLE
add redundant tag to coffeematch message

### DIFF
--- a/src/commands/coffeechats/coffeeMatch.ts
+++ b/src/commands/coffeechats/coffeeMatch.ts
@@ -48,9 +48,11 @@ class CoffeeMatchCommand extends AdminCommand {
       const userTargets = targets.map((value) => userMap.get(value)!);
       try {
         if (targets.length > 1) {
-          await discordUser.send(`Your coffee chat matches for this week are ${_.join(userTargets, ' and ')}`);
+          await discordUser.send(
+            `Your coffee chat matches for this week are ${userTargets[0].tag} (${userTargets[0]}) and ${userTargets[1].tag} (${userTargets[1]}).`
+          );
         } else {
-          await discordUser.send(`Your coffee chat match for this week is ${userTargets[0]}`);
+          await discordUser.send(`Your coffee chat match for this week is ${userTargets[0].tag} (${userTargets[0]}).`);
         }
       } catch (err) {
         logError(err as Error);


### PR DESCRIPTION

Add tags before mention as redundancy, in case discord loses cache.
![image](https://user-images.githubusercontent.com/39033120/153728221-42ec6564-1c69-439e-94ea-111489fcaa7f.png)
