### PR TITLE
Coffee chat and suggestion fixes

### DIFF
--- a/src/commands/suggestions/suggestionsList.ts
+++ b/src/commands/suggestions/suggestionsList.ts
@@ -17,7 +17,7 @@ class SuggestionsListCommand extends AdminCommand {
   constructor(client: CommandoClient) {
     super(client, {
       name: 'suggestions-list',
-      aliases: ['suggestions', 'suggestion-list', 'suggestions-list', 'suggest-list'],
+      aliases: ['suggestions', 'suggestion-list', 'suggest-list'],
       group: 'suggestions',
       memberName: 'list',
       args: [

--- a/src/components/coffeechat.ts
+++ b/src/components/coffeechat.ts
@@ -75,7 +75,7 @@ const getMaxDupe = (matched: number[][], matches: string[][], userList: Map<stri
  */
 const loadMatched = async (notMatched: Map<string, number>): Promise<number[][]> => {
   const db = await openDB();
-  const matched: number[][] = Array.from(Array(notMatched.size), () => new Array(4).fill(0));
+  const matched: number[][] = Array.from(Array(notMatched.size), () => new Array(notMatched.size).fill(0));
   const matches = (await db.all(`SELECT * FROM coffee_historic_matches`)) as historic_match[];
   for (const { first_user_id, second_user_id } of matches) {
     if (notMatched.has(first_user_id) && notMatched.has(second_user_id)) {


### PR DESCRIPTION
# Related Issues
N/A

# Summary of Changes 
- Fixed array size for coffee chat
- Removed the redundant alias `suggestions-list`

# Steps to Reproduce
For the coffee chat fix, if you do `console.log(matched)`, then it should not have NaN entries anymore for when there are at least 5 people participating