### PR TITLE
parse error obj to string before logging

### DIFF
--- a/src/components/logger.ts
+++ b/src/components/logger.ts
@@ -29,7 +29,7 @@ const logger = winston.createLogger({
 export const logError = (err: Error, event = 'client', data: { [key: string]: string } = {}): void => {
   logger.error({
     event: `${event}_error`,
-    error: err,
+    error: err.toString(),
     ...data
   });
 };


### PR DESCRIPTION
# Related Issues
N/A

# Summary of Changes 
Error objects were not visible through the GCP log viewer because they were not serialized properly. This PR parses the error object into a string before logging.

# Steps to Reproduce
Run `.coffeematch` on staging (erroring out ATM)
