### PR TITLE
added aliases, more validation and embed message inlining for user profiles

### DIFF
--- a/src/commands/profile/profile.ts
+++ b/src/commands/profile/profile.ts
@@ -9,6 +9,7 @@ import {
   getUserProfileById,
   UserProfile,
   validCustomizations,
+  validCustomizationsDisplay,
   validUserCustomization
 } from '../../components/profile';
 import { EMBED_COLOUR } from '../../utils/embeds';
@@ -80,8 +81,9 @@ export class ProfileCommand extends SubCommandPluginCommand {
   public async set(message: Message, args: Args): Promise<Message> {
     const { author } = message;
     const customization = <keyof typeof configMaps>await args.pick('string').catch(() => false);
-    if (typeof customization === 'boolean') {
-      return message.reply(`Please enter a customization. Must be one of**${validCustomizations}**`);
+    // if no customization is supplied, or its not one of the customizations we provide, return
+    if (typeof customization === 'boolean' || !validCustomizations.includes(customization)) {
+      return message.reply(`Please enter a customization. Must be one of**${validCustomizationsDisplay}**`);
     }
     const description = await args.rest('string').catch(() => false);
     if (typeof description === 'boolean') {
@@ -92,6 +94,7 @@ export class ProfileCommand extends SubCommandPluginCommand {
       editUserProfileById(author.id, { [configMaps[customization]]: parsedDescription } as UserProfile);
       return message.reply(`${customization} has been set!`);
     }
+    // if reason is not valid the reason will be returned by the validUserCustomization function
     const messagePrefix = 'Invalid arguments, please try again. Reason: ';
     return message.reply(messagePrefix + reason);
   }

--- a/src/commands/profile/profile.ts
+++ b/src/commands/profile/profile.ts
@@ -14,11 +14,11 @@ import {
 import { EMBED_COLOUR } from '../../utils/embeds';
 
 @ApplyOptions<SubCommandPluginCommandOptions>({
-  aliases: ['profile', 'userprofile'],
+  aliases: ['profile', 'userprofile', 'aboutme'],
   description: 'Handles user profile functions',
   detailedDescription: `**Examples:**
 \`${container.botPrefix}profile @Codey\``,
-  subCommands: [{ input: 'about', default: true}, 'set']
+  subCommands: [{ input: 'about', default: true }, 'set']
 })
 export class ProfileCommand extends SubCommandPluginCommand {
   public async about(message: Message, args: Args): Promise<Message> {
@@ -54,10 +54,15 @@ export class ProfileCommand extends SubCommandPluginCommand {
           // iterate through each of the configurations, prettyProfileDetails making the configuration more readable
           // as opposed to snake case
           // need to cast val to string since addField does not take in numbers
-          if (key === "about_me"){ // about me can be pretty long, so we do not inline it   
+          if (key === 'about_me') {
+            // about me can be pretty long, so we do not inline it
             profileDisplay.addField(prettyProfileDetails[key as keyof typeof prettyProfileDetails], val.toString());
           } else {
-            profileDisplay.addField(prettyProfileDetails[key as keyof typeof prettyProfileDetails], val.toString(), true);
+            profileDisplay.addField(
+              prettyProfileDetails[key as keyof typeof prettyProfileDetails],
+              val.toString(),
+              true
+            );
           }
         }
       }
@@ -65,8 +70,8 @@ export class ProfileCommand extends SubCommandPluginCommand {
       const userCoins = (await getCoinBalanceByUserId(user.id)).toString();
       profileDisplay.addField('Codey Coins', userCoins, true);
       // display last updated last
-      if (profileDetails['last_updated']){
-        profileDisplay.addField(prettyProfileDetails.last_updated, profileDetails['last_updated'], true)
+      if (profileDetails['last_updated']) {
+        profileDisplay.addField(prettyProfileDetails.last_updated, profileDetails['last_updated'], true);
       }
       return message.channel.send({ embeds: [profileDisplay] });
     }

--- a/src/commands/profile/profile.ts
+++ b/src/commands/profile/profile.ts
@@ -10,7 +10,8 @@ import {
   UserProfile,
   validCustomizations,
   validCustomizationsDisplay,
-  validUserCustomization
+  validUserCustomization,
+  prettyProfileDetails
 } from '../../components/profile';
 import { EMBED_COLOUR } from '../../utils/embeds';
 
@@ -23,18 +24,6 @@ import { EMBED_COLOUR } from '../../utils/embeds';
 })
 export class ProfileCommand extends SubCommandPluginCommand {
   public async about(message: Message, args: Args): Promise<Message> {
-    enum prettyProfileDetails {
-      about_me = 'About Me',
-      birth_date = 'Birth Date',
-      preferred_name = 'Preferred Name',
-      preferred_pronouns = 'Preferred Pronouns',
-      term = 'Term',
-      year = 'Year',
-      faculty = 'Faculty',
-      program = 'Program',
-      specialization = 'Specialization',
-      last_updated = 'Last Updated'
-    }
     const user = await args.rest('user').catch(() => 'please enter a valid user mention or ID to check their profile.');
     if (typeof user === 'string') return message.reply(user);
     // get user profile if exists
@@ -55,16 +44,11 @@ export class ProfileCommand extends SubCommandPluginCommand {
           // iterate through each of the configurations, prettyProfileDetails making the configuration more readable
           // as opposed to snake case
           // need to cast val to string since addField does not take in numbers
-          if (key === 'about_me') {
-            // about me can be pretty long, so we do not inline it
-            profileDisplay.addField(prettyProfileDetails[key as keyof typeof prettyProfileDetails], val.toString());
-          } else {
-            profileDisplay.addField(
-              prettyProfileDetails[key as keyof typeof prettyProfileDetails],
-              val.toString(),
-              true
-            );
-          }
+          profileDisplay.addField(
+            prettyProfileDetails[key as keyof typeof prettyProfileDetails],
+            val.toString(),
+            key !== 'about_me' // since about_me can be long, we dont want to inline it
+          );
         }
       }
       // add codeycoins onto the fields as well

--- a/src/components/profile.ts
+++ b/src/components/profile.ts
@@ -10,6 +10,7 @@ export interface UserProfile {
   faculty?: string;
   program?: string;
   specialization?: string;
+  last_updated?: string;
 }
 
 const validFaculties = ['Mathematics', 'Engineering', 'Arts', 'Health', 'Science'];

--- a/src/components/profile.ts
+++ b/src/components/profile.ts
@@ -30,6 +30,19 @@ export enum configMaps {
   specialization = 'specialization'
 }
 
+export enum prettyProfileDetails {
+  about_me = 'About Me',
+  birth_date = 'Birth Date',
+  preferred_name = 'Preferred Name',
+  preferred_pronouns = 'Preferred Pronouns',
+  term = 'Term',
+  year = 'Year',
+  faculty = 'Faculty',
+  program = 'Program',
+  specialization = 'Specialization',
+  last_updated = 'Last Updated'
+}
+
 const validBirthdates = [
   'January',
   'February',

--- a/src/components/profile.ts
+++ b/src/components/profile.ts
@@ -72,19 +72,16 @@ enum validatedFields {
   year = 'year'
 }
 
-export const validCustomizations = `${(Object.keys(configMaps) as Array<keyof typeof configMaps>).map(
-  (key) => ' ' + key
-)}`;
+export const validCustomizations = Object.keys(configMaps) as Array<keyof typeof configMaps>;
 
+export const validCustomizationsDisplay = `${validCustomizations.map((key) => ' ' + key)}`;
+
+// validUserCustomization checks the customization description to ensure it is proper
+// and also returns a formatted version of their description (proper capitalization)
 export const validUserCustomization = (
   customization: keyof typeof configMaps,
   description: string
 ): userCustomization => {
-  if (!(Object.keys(configMaps) as Array<keyof typeof configMaps>).includes(customization)) {
-    return {
-      reason: `Invalid customization selection. Must be one of**${validCustomizations}**`
-    };
-  }
   let parsedDescription = description;
   if (customization !== validatedFields.term) {
     // convert first letter to capital in case the user doesnt use proper capitalization


### PR DESCRIPTION
# Related Issues
resolves <https://github.com/uwcsc/codeybot/issues/189>

# Summary of Changes 
Previously user profile was very vertical. some fields do not need to take up an entire row. Validation was also unclear at some times so I changed that a bit. Also, I added the userprofile and aboutme alias and made profile about the default command.

# Steps to Reproduce
Set up your user profile (.profile set <field> <description>) for multiple fields. Check out that it is not as vertical anymore.
Previous
<img width="247" alt="image" src="https://user-images.githubusercontent.com/36215359/167279594-936f1efc-3c5e-41f8-8e99-445fabd0115c.png">

New
<img width="658" alt="image" src="https://user-images.githubusercontent.com/36215359/167279602-2581d31a-7950-49c0-b812-bc41398bf263.png">

