### PR TITLE
Fix use of single quote character

### DIFF
--- a/src/components/profile.ts
+++ b/src/components/profile.ts
@@ -156,6 +156,8 @@ export const editUserProfileById = async (userId: string, data: UserProfile): Pr
       onlyCustomization = customization;
       onlyDescription = description;
     }
+    // escape any instances of ' character by placing another ' in front of it by sqlite specifications
+    onlyDescription.replace(/'/g, "''");
     query = `UPDATE user_profile_table SET last_updated=CURRENT_DATE, ${onlyCustomization}=? WHERE user_id=?`;
     await db.run(query, onlyDescription, userId);
   } else {
@@ -169,6 +171,9 @@ export const editUserProfileById = async (userId: string, data: UserProfile): Pr
     }
     query = query.concat(`VALUES (?, CURRENT_DATE, ?)`);
     // there is only one element in object.values (which is the description)
-    await db.run(query, userId, Object.values(data)[0]);
+    const description = Object.values(data)[0];
+    // escape any instances of ' character by placing another ' in front of it by sqlite specifications
+    description.replace(/'/g, "''");
+    await db.run(query, userId, description);
   }
 };


### PR DESCRIPTION
# Related Issues
resolves <https://github.com/uwcsc/codeybot/issues/209>.

# Summary of Changes 
- Escaped all instances of single quote character, allowing it to be used in descriptions.
- Note that this does NOT fix the use of double quotes. It seems sapphire does not support the quotation character as part of user args as it is already removed when first received.

# Steps to Reproduce
- .profile set aboutme SOME_DESCRIPTION_WITH_SINGLE_QUOTES
- .profile about YOUR_USERNAME
- Observe that the quotes appear properly now

<img width="512" alt="image" src="https://user-images.githubusercontent.com/36215359/172030880-966b7e6e-42b1-4c1f-ac30-9a65713da5ae.png">

