### PR TITLE
Cleared assignee from issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -3,7 +3,6 @@ name: "\U0001F41E Bug Report"
 about: Help us improve and fix existing issues
 title: '[BUG]'
 labels: bug
-assignees: asdera
 ---
 
 **Describe the bug**

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -3,7 +3,6 @@ name: "\U0001F4DD Feature Request"
 about: Suggest a new feature for the bot
 title: '[FEATURE]'
 labels: request
-assignees: asdera
 ---
 
 **Describe the problem and the impact.**


### PR DESCRIPTION
# Related Issues
<!-- Issue(s) that this PR will resolve, e.g. "resolves <issue link here>". -->
N/A

# Summary of Changes
<!-- A summary or description of changes made in this PR. -->
The assignee from issue templates is removed because this is outdated. In addition, a newly created issue is usually up for grabs, so there is now no default assignee.

# Steps to Reproduce
<!-- List the steps needed for the reviewer to produce your PR changes. -->
The changes should be seen in the future when using an issue template