### PR TITLE
Only edit message for ping

### DIFF
--- a/src/codeyCommand.ts
+++ b/src/codeyCommand.ts
@@ -47,13 +47,11 @@ export class CodeyCommand extends SapphireCommand {
   }
 
   // Regular command
-  public async messageRun(message: Message): Promise<Message<boolean>> {
+  public async messageRun(message: Message): Promise<Message<boolean> | undefined> {
     const { client } = container;
-    const initialMessageFromBot: SapphireMessageRequest = await message.channel.send({
-      content: this.messageWhenExecutingCommand
-    });
     try {
-      const successResponse = await this.executeCommand(client, message, initialMessageFromBot);
+      const successResponse = await this.executeCommand(client, message);
+      if (!successResponse) return;
       switch (this.codeyCommandResponseType) {
         case CodeyCommandResponseType.EMBED:
           return await message.channel.send({ embeds: [<MessageEmbed>successResponse] });
@@ -67,7 +65,9 @@ export class CodeyCommand extends SapphireCommand {
   }
 
   // Slash command
-  public async chatInputRun(interaction: SapphireCommand.ChatInputInteraction): Promise<APIMessage | Message<boolean>> {
+  public async chatInputRun(
+    interaction: SapphireCommand.ChatInputInteraction
+  ): Promise<APIMessage | Message<boolean> | undefined> {
     const { client } = container;
     const initialMessageFromBot: SapphireMessageRequest = await interaction.reply({
       content: this.messageWhenExecutingCommand,

--- a/src/codeyCommand.ts
+++ b/src/codeyCommand.ts
@@ -65,9 +65,7 @@ export class CodeyCommand extends SapphireCommand {
   }
 
   // Slash command
-  public async chatInputRun(
-    interaction: SapphireCommand.ChatInputInteraction
-  ): Promise<APIMessage | Message<boolean> | undefined> {
+  public async chatInputRun(interaction: SapphireCommand.ChatInputInteraction): Promise<APIMessage | Message<boolean>> {
     const { client } = container;
     const initialMessageFromBot: SapphireMessageRequest = await interaction.reply({
       content: this.messageWhenExecutingCommand,


### PR DESCRIPTION
# Related Issues
<!-- Issue(s) that this PR will resolve, e.g. "resolves <issue link here>". -->
N/A

# Summary of Changes
<!-- A summary or description of changes made in this PR. -->
Originally, non-slash commands used to send both the `messageWhenExecutingCommand` and the final response. Now, only `ping` would edit the message from `messageWhenExecutingCommand` to the final response and the other commands would only send the final response.

# Steps to Reproduce
<!-- List the steps needed for the reviewer to produce your PR changes.
     If possible, also include screenshots to illustrate your new feature or fix. -->
Try out the commands
![image](https://user-images.githubusercontent.com/58180935/179049805-8c309da8-2aa3-4401-882a-c2df523bb49c.png)
