### PR TITLE
Adding options and subcommands to CodeyCommand

### DIFF
--- a/src/bot.ts
+++ b/src/bot.ts
@@ -6,6 +6,8 @@ import '@sapphire/plugin-logger/register';
 import * as colorette from 'colorette';
 import { inspect } from 'util';
 
+import { RegisterBehavior } from '@sapphire/framework';
+
 // Set default inspection depth
 inspect.defaultOptions.depth = 2;
 

--- a/src/bot.ts
+++ b/src/bot.ts
@@ -6,8 +6,6 @@ import '@sapphire/plugin-logger/register';
 import * as colorette from 'colorette';
 import { inspect } from 'util';
 
-import { RegisterBehavior } from '@sapphire/framework';
-
 // Set default inspection depth
 inspect.defaultOptions.depth = 2;
 

--- a/src/codeyCommand.ts
+++ b/src/codeyCommand.ts
@@ -232,9 +232,13 @@ export class CodeyCommand extends SapphireCommand {
       );
     }
 
+    let subcommandName = message.content.split(' ')[1];
+    /** The command details object to use */
+    let commandDetails = this.details.subcommandDetails[subcommandName] ?? this.details;
+
     try {
-      const successResponse = await this.details.executeCommand(client, message, initialMessageFromBot, args);
-      switch (this.details.codeyCommandResponseType) {
+      const successResponse = await commandDetails.executeCommand(client, message, initialMessageFromBot, args);
+      switch (commandDetails.codeyCommandResponseType) {
         case CodeyCommandResponseType.EMBED:
           return await message.channel.send({ embeds: [<MessageEmbed>successResponse] });
         case CodeyCommandResponseType.STRING:
@@ -242,7 +246,7 @@ export class CodeyCommand extends SapphireCommand {
       }
     } catch (e) {
       console.log(e);
-      return await message.channel.send(this.details.messageIfFailure);
+      return await message.channel.send(commandDetails.messageIfFailure);
     }
   }
 
@@ -262,11 +266,14 @@ export class CodeyCommand extends SapphireCommand {
         .map((commandOption) => commandOption.name)
         .map((commandOptionName) => ({ [commandOptionName]: interaction.options.get(commandOptionName)?.value }))
     );
+    
+    /** The command details object to use */
+    let commandDetails = this.details.subcommandDetails[interaction.options.getSubcommand()] ?? this.details;
 
     if (isMessageInstance(initialMessageFromBot)) {
       try {
-        const successResponse = await this.details.executeCommand(client, interaction, initialMessageFromBot, args);
-        switch (this.details.codeyCommandResponseType) {
+        const successResponse = await commandDetails.executeCommand(client, interaction, initialMessageFromBot, args);
+        switch (commandDetails.codeyCommandResponseType) {
           case CodeyCommandResponseType.EMBED:
             const currentChannel = (await client.channels.fetch(interaction.channelId)) as TextChannel;
             return currentChannel.send({ embeds: [<MessageEmbed>successResponse] });
@@ -275,9 +282,9 @@ export class CodeyCommand extends SapphireCommand {
         }
       } catch (e) {
         console.log(e);
-        return interaction.editReply(this.details.messageIfFailure);
+        return interaction.editReply(commandDetails.messageIfFailure);
       }
     }
-    return interaction.editReply(this.details.messageIfFailure);
+    return interaction.editReply(commandDetails.messageIfFailure);
   }
 }

--- a/src/codeyCommand.ts
+++ b/src/codeyCommand.ts
@@ -272,10 +272,10 @@ export class CodeyCommand extends SapphireCommand {
     );
 
     // Get subcommand name
-    let subcommandName: string = '';
+    let subcommandName = '';
     try {
       subcommandName = interaction.options.getSubcommand();
-    } catch (e: any) {}
+    } catch (e) {}
     /** The command details object to use */
     const commandDetails = this.details.subcommandDetails[subcommandName] ?? this.details;
 

--- a/src/codeyCommand.ts
+++ b/src/codeyCommand.ts
@@ -148,26 +148,45 @@ export type CodeyCommandArgumentValueType = string | number | boolean | undefine
 /** A standardized dictionary that stores the arguments of the command */
 export type CodeyCommandArguments = { [key: string]: CodeyCommandArgumentValueType };
 
-export class CodeyCommand extends SapphireCommand {
-  // The message to display whilst the command is executing
-  messageWhenExecutingCommand!: string;
-  // The function to be called when the command is executing
-  executeCommand!: SapphireMessageExecuteType;
-  // The message to display if the command fails
-  messageIfFailure = 'Codey backend error - contact a mod for assistance';
+/** Details for the codey command (or subcommand) */
+export class CodeyCommandDetails {
+  /** The name of the command */
+  name!: string;
+  /** The aliases of the command (for regular commands) */
+  aliases: string[] = [];
+  /** A short description of the command (shown in the slash command menu) */
+  description: string = `Codey command for ${this.name}`;
+  /** A longer description of the command (shown in the help menu for the command) */
+  detailedDescription: string = this.description;
 
-  isCommandResponseEphemeral = true;
-  // Type of response Codey command sends
+
+  /** The message to display when the command is executing (for slash commands) */
+  messageWhenExecutingCommand!: string;
+  /** The function to be called to execute the command */
+  executeCommand!: SapphireMessageExecuteType;
+  /** The message to display if the command fails */
+  messageIfFailure: string = 'Codey backend error - contact a mod for assistance';
+  /** A flag to indicate if the command response is ephemeral (ie visible to others) */
+  isCommandResponseEphemeral: boolean = true;
+  /** Type of response the Codey command sends */
   codeyCommandResponseType: CodeyCommandResponseType = CodeyCommandResponseType.STRING;
 
-  // Command options
-  commandOptions: CodeyCommandOption[] = [];
+  /** Options for the Codey command */
+  options: CodeyCommandOption[] = [];
+  /** Subcommands under the CodeyCommand */
+  subcommandDetails: {[name: string]: CodeyCommandDetails} = {};
+}
+
+/** The codey command class */
+export class CodeyCommand extends SapphireCommand {
+  /** The details of the command */
+  details!: CodeyCommandDetails;
 
   // Get slash command builder
   public configureSlashCommandBuilder(builder: SlashCommandBuilder): SlashCommandBuilder {
-    builder.setName(this.name);
-    builder.setDescription(this.description);
-    for (const commandOption of this.commandOptions) {
+    builder.setName(this.details.name);
+    builder.setDescription(this.details.description);
+    for (const commandOption of this.details.options) {
       setCommandOption(builder, commandOption);
     }
     return builder;
@@ -187,20 +206,20 @@ export class CodeyCommand extends SapphireCommand {
   public async messageRun(message: Message, commandArgs: Args): Promise<Message<boolean>> {
     const { client } = container;
     const initialMessageFromBot: SapphireMessageRequest = await message.channel.send({
-      content: this.messageWhenExecutingCommand
+      content: this.details.messageWhenExecutingCommand
     });
 
     // Get command arguments
     const args: CodeyCommandArguments = {};
-    for (const commandOption of this.commandOptions) {
+    for (const commandOption of this.details.options!) {
       args[commandOption.name] = <CodeyCommandArgumentValueType>(
         await commandArgs.pick(<keyof ArgType>commandOption.type)
       );
     }
 
     try {
-      const successResponse = await this.executeCommand(client, message, initialMessageFromBot, args);
-      switch (this.codeyCommandResponseType) {
+      const successResponse = await this.details.executeCommand(client, message, initialMessageFromBot, args);
+      switch (this.details.codeyCommandResponseType) {
         case CodeyCommandResponseType.EMBED:
           return await message.channel.send({ embeds: [<MessageEmbed>successResponse] });
         case CodeyCommandResponseType.STRING:
@@ -208,7 +227,7 @@ export class CodeyCommand extends SapphireCommand {
       }
     } catch (e) {
       console.log(e);
-      return await message.channel.send(this.messageIfFailure);
+      return await message.channel.send(this.details.messageIfFailure);
     }
   }
 
@@ -216,23 +235,23 @@ export class CodeyCommand extends SapphireCommand {
   public async chatInputRun(interaction: SapphireCommand.ChatInputInteraction): Promise<APIMessage | Message<boolean>> {
     const { client } = container;
     const initialMessageFromBot: SapphireMessageRequest = await interaction.reply({
-      content: this.messageWhenExecutingCommand,
-      ephemeral: this.isCommandResponseEphemeral, // whether user sees message or not
+      content: this.details.messageWhenExecutingCommand,
+      ephemeral: this.details.isCommandResponseEphemeral, // whether user sees message or not
       fetchReply: true
     });
 
     // Get command arguments
     const args: CodeyCommandArguments = Object.assign(
       {},
-      ...this.commandOptions
+      ...this.details.options
         .map((commandOption) => commandOption.name)
         .map((commandOptionName) => ({ [commandOptionName]: interaction.options.get(commandOptionName)?.value }))
     );
 
     if (isMessageInstance(initialMessageFromBot)) {
       try {
-        const successResponse = await this.executeCommand(client, interaction, initialMessageFromBot, args);
-        switch (this.codeyCommandResponseType) {
+        const successResponse = await this.details.executeCommand(client, interaction, initialMessageFromBot, args);
+        switch (this.details.codeyCommandResponseType) {
           case CodeyCommandResponseType.EMBED:
             const currentChannel = (await client.channels.fetch(interaction.channelId)) as TextChannel;
             return currentChannel.send({ embeds: [<MessageEmbed>successResponse] });
@@ -241,9 +260,9 @@ export class CodeyCommand extends SapphireCommand {
         }
       } catch (e) {
         console.log(e);
-        return interaction.editReply(this.messageIfFailure);
+        return interaction.editReply(this.details.messageIfFailure);
       }
     }
-    return interaction.editReply(this.messageIfFailure);
+    return interaction.editReply(this.details.messageIfFailure);
   }
 }

--- a/src/codeyCommand.ts
+++ b/src/codeyCommand.ts
@@ -154,8 +154,7 @@ export class CodeyCommand extends SapphireCommand {
   commandOptions: CodeyCommandOption[] = [];
 
   // Get slash command builder
-  public getSlashCommandBuilder(): SlashCommandBuilder {
-    const builder = new SlashCommandBuilder();
+  public configureSlashCommandBuilder(builder: SlashCommandBuilder): SlashCommandBuilder {
     builder.setName(this.name);
     builder.setDescription(this.description);
     for (const commandOption of this.commandOptions) {
@@ -168,7 +167,8 @@ export class CodeyCommand extends SapphireCommand {
   public override registerApplicationCommands(registry: ChatInputCommand.Registry): void {
     // This ensures any new changes are made to the slash commands are made
     ApplicationCommandRegistries.setDefaultBehaviorWhenNotIdentical(RegisterBehavior.Overwrite);
-    registry.registerChatInputCommand(this.getSlashCommandBuilder());
+    // We need to do this because TS is weird
+    registry.registerChatInputCommand(builder => this.configureSlashCommandBuilder(<SlashCommandBuilder> <unknown> builder));
   }
 
   // Regular command

--- a/src/codeyCommand.ts
+++ b/src/codeyCommand.ts
@@ -1,10 +1,28 @@
-import { ApplicationCommandRegistries, ChatInputCommand, Command as SapphireCommand, container, Args, ArgType, RegisterBehavior, SapphireClient } from '@sapphire/framework';
+import {
+  ApplicationCommandRegistries,
+  ChatInputCommand,
+  Command as SapphireCommand,
+  container,
+  Args,
+  ArgType,
+  RegisterBehavior,
+  SapphireClient
+} from '@sapphire/framework';
 import { Message, MessageEmbed, MessagePayload, TextChannel, WebhookEditMessageOptions } from 'discord.js';
 import { APIMessage } from 'discord-api-types/v9';
 import { isMessageInstance } from '@sapphire/discord.js-utilities';
-import { SlashCommandBuilder, SlashCommandStringOption, SlashCommandIntegerOption, SlashCommandBooleanOption,
-  SlashCommandUserOption, SlashCommandChannelOption, SlashCommandRoleOption,
-  SlashCommandMentionableOption, SlashCommandNumberOption, SlashCommandAttachmentOption} from '@discordjs/builders';
+import {
+  SlashCommandBuilder,
+  SlashCommandStringOption,
+  SlashCommandIntegerOption,
+  SlashCommandBooleanOption,
+  SlashCommandUserOption,
+  SlashCommandChannelOption,
+  SlashCommandRoleOption,
+  SlashCommandMentionableOption,
+  SlashCommandNumberOption,
+  SlashCommandAttachmentOption
+} from '@discordjs/builders';
 
 export type SapphireMessageRequest = APIMessage | Message<boolean>;
 export type SapphireMessageResponse = string | MessagePayload | WebhookEditMessageOptions | MessageEmbed;
@@ -37,9 +55,16 @@ export enum CodeyCommandOptionType {
   ATTACHMENT = 'attachment'
 }
 
-type SlashCommandOption = SlashCommandStringOption | SlashCommandIntegerOption | SlashCommandBooleanOption
-| SlashCommandUserOption | SlashCommandChannelOption | SlashCommandRoleOption
-| SlashCommandMentionableOption | SlashCommandNumberOption | SlashCommandAttachmentOption;
+type SlashCommandOption =
+  | SlashCommandStringOption
+  | SlashCommandIntegerOption
+  | SlashCommandBooleanOption
+  | SlashCommandUserOption
+  | SlashCommandChannelOption
+  | SlashCommandRoleOption
+  | SlashCommandMentionableOption
+  | SlashCommandNumberOption
+  | SlashCommandAttachmentOption;
 
 export interface CodeyCommandOption {
   name: string;
@@ -49,70 +74,69 @@ export interface CodeyCommandOption {
 }
 
 const setCommandOption = (builder: SlashCommandBuilder, option: CodeyCommandOption): SlashCommandBuilder => {
-  // TODO: implement other command option types
-  let commandOption;
+  let commandOption: SlashCommandOption;
   switch (option.type) {
     case CodeyCommandOptionType.STRING:
       commandOption = new SlashCommandStringOption();
       commandOption.setName(option.name);
       commandOption.setDescription(option.description);
       commandOption.setRequired(option.required);
-      return <SlashCommandBuilder> builder.addStringOption(commandOption);
+      return <SlashCommandBuilder>builder.addStringOption(commandOption);
     case CodeyCommandOptionType.INTEGER:
       commandOption = new SlashCommandIntegerOption();
       commandOption.setName(option.name);
       commandOption.setDescription(option.description);
       commandOption.setRequired(option.required);
-      return <SlashCommandBuilder> builder.addIntegerOption(commandOption);
+      return <SlashCommandBuilder>builder.addIntegerOption(commandOption);
     case CodeyCommandOptionType.BOOLEAN:
       commandOption = new SlashCommandBooleanOption();
       commandOption.setName(option.name);
       commandOption.setDescription(option.description);
       commandOption.setRequired(option.required);
-      return <SlashCommandBuilder> builder.addBooleanOption(commandOption);
+      return <SlashCommandBuilder>builder.addBooleanOption(commandOption);
     case CodeyCommandOptionType.USER:
       commandOption = new SlashCommandUserOption();
       commandOption.setName(option.name);
       commandOption.setDescription(option.description);
       commandOption.setRequired(option.required);
-      return <SlashCommandBuilder> builder.addUserOption(commandOption);
+      return <SlashCommandBuilder>builder.addUserOption(commandOption);
     case CodeyCommandOptionType.CHANNEL:
       commandOption = new SlashCommandChannelOption();
       commandOption.setName(option.name);
       commandOption.setDescription(option.description);
       commandOption.setRequired(option.required);
-      return <SlashCommandBuilder> builder.addChannelOption(commandOption);
+      return <SlashCommandBuilder>builder.addChannelOption(commandOption);
     case CodeyCommandOptionType.ROLE:
       commandOption = new SlashCommandRoleOption();
       commandOption.setName(option.name);
       commandOption.setDescription(option.description);
       commandOption.setRequired(option.required);
-      return <SlashCommandBuilder> builder.addRoleOption(commandOption);
-      case CodeyCommandOptionType.MENTIONABLE:
-        commandOption = new SlashCommandMentionableOption();
-        commandOption.setName(option.name);
-        commandOption.setDescription(option.description);
-        commandOption.setRequired(option.required);
-        return <SlashCommandBuilder> builder.addMentionableOption(commandOption);
-      case CodeyCommandOptionType.NUMBER:
-        commandOption = new SlashCommandNumberOption();
-        commandOption.setName(option.name);
-        commandOption.setDescription(option.description);
-        commandOption.setRequired(option.required);
-        return <SlashCommandBuilder> builder.addNumberOption(commandOption);
-        case CodeyCommandOptionType.ATTACHMENT:
-          commandOption = new SlashCommandAttachmentOption();
-          commandOption.setName(option.name);
-          commandOption.setDescription(option.description);
-          commandOption.setRequired(option.required);
-          return <SlashCommandBuilder> builder.addAttachmentOption(commandOption);
+      return <SlashCommandBuilder>builder.addRoleOption(commandOption);
+    case CodeyCommandOptionType.MENTIONABLE:
+      commandOption = new SlashCommandMentionableOption();
+      commandOption.setName(option.name);
+      commandOption.setDescription(option.description);
+      commandOption.setRequired(option.required);
+      return <SlashCommandBuilder>builder.addMentionableOption(commandOption);
+    case CodeyCommandOptionType.NUMBER:
+      commandOption = new SlashCommandNumberOption();
+      commandOption.setName(option.name);
+      commandOption.setDescription(option.description);
+      commandOption.setRequired(option.required);
+      return <SlashCommandBuilder>builder.addNumberOption(commandOption);
+    case CodeyCommandOptionType.ATTACHMENT:
+      commandOption = new SlashCommandAttachmentOption();
+      commandOption.setName(option.name);
+      commandOption.setDescription(option.description);
+      commandOption.setRequired(option.required);
+      return <SlashCommandBuilder>builder.addAttachmentOption(commandOption);
     default:
-      throw new Error(`Unknown option type.`)
+      throw new Error(`Unknown option type.`);
   }
-}
+};
 
 export type CodeyCommandArgumentValueType = string | number | boolean | undefined;
-export type CodeyCommandArguments = {[key: string]: CodeyCommandArgumentValueType};
+export type CodeyCommandArguments = { [key: string]: CodeyCommandArgumentValueType };
 
 export class CodeyCommand extends SapphireCommand {
   // The message to display whilst the command is executing
@@ -134,7 +158,7 @@ export class CodeyCommand extends SapphireCommand {
     const builder = new SlashCommandBuilder();
     builder.setName(this.name);
     builder.setDescription(this.description);
-    for (let commandOption of this.commandOptions) {
+    for (const commandOption of this.commandOptions) {
       setCommandOption(builder, commandOption);
     }
     return builder;
@@ -148,7 +172,6 @@ export class CodeyCommand extends SapphireCommand {
   }
 
   // Regular command
-  // TODO: implement options for regular commands
   public async messageRun(message: Message, commandArgs: Args): Promise<Message<boolean>> {
     const { client } = container;
     const initialMessageFromBot: SapphireMessageRequest = await message.channel.send({
@@ -157,8 +180,10 @@ export class CodeyCommand extends SapphireCommand {
 
     // Get command arguments
     const args: CodeyCommandArguments = {};
-    for (let commandOption of this.commandOptions) {
-      args[commandOption.name] = <CodeyCommandArgumentValueType> await commandArgs.pick(<keyof ArgType> commandOption.type);
+    for (const commandOption of this.commandOptions) {
+      args[commandOption.name] = <CodeyCommandArgumentValueType>(
+        await commandArgs.pick(<keyof ArgType>commandOption.type)
+      );
     }
 
     try {
@@ -185,10 +210,12 @@ export class CodeyCommand extends SapphireCommand {
     });
 
     // Get command arguments
-    const args: CodeyCommandArguments = Object.assign({},
+    const args: CodeyCommandArguments = Object.assign(
+      {},
       ...this.commandOptions
-      .map(commandOption => commandOption.name)
-      .map(commandOptionName => ({[commandOptionName]: interaction.options.get(commandOptionName)?.value})));
+        .map((commandOption) => commandOption.name)
+        .map((commandOptionName) => ({ [commandOptionName]: interaction.options.get(commandOptionName)?.value }))
+    );
 
     if (isMessageInstance(initialMessageFromBot)) {
       try {

--- a/src/codeyCommand.ts
+++ b/src/codeyCommand.ts
@@ -178,7 +178,9 @@ export class CodeyCommand extends SapphireCommand {
     // This ensures any new changes are made to the slash commands are made
     ApplicationCommandRegistries.setDefaultBehaviorWhenNotIdentical(RegisterBehavior.Overwrite);
     // We need to do this because TS is weird
-    registry.registerChatInputCommand(builder => this.configureSlashCommandBuilder(<SlashCommandBuilder> <unknown> builder));
+    registry.registerChatInputCommand((builder) =>
+      this.configureSlashCommandBuilder(<SlashCommandBuilder>(<unknown>builder))
+    );
   }
 
   // Regular command

--- a/src/codeyCommand.ts
+++ b/src/codeyCommand.ts
@@ -33,9 +33,9 @@ export type SapphireMessageExecuteType = (
   client: SapphireClient<boolean>,
   // Message is for normal commands, ChatInputInteraction is for slash commands
   messageFromUser: Message | SapphireCommand.ChatInputInteraction,
-  initialMessageFromBot?: SapphireMessageRequest,
   // Command arguments
-  args?: CodeyCommandArguments
+  args: CodeyCommandArguments,
+  initialMessageFromBot?: SapphireMessageRequest
 ) => Promise<SapphireMessageResponse>;
 
 // Type of response the Codey command will send
@@ -240,7 +240,7 @@ export class CodeyCommand extends SapphireCommand {
     const commandDetails = this.details.subcommandDetails[subcommandName] ?? this.details;
 
     try {
-      const successResponse = await commandDetails.executeCommand(client, message, undefined, args);
+      const successResponse = await commandDetails.executeCommand(client, message, args);
       if (!successResponse) return;
       switch (commandDetails.codeyCommandResponseType) {
         case CodeyCommandResponseType.EMBED:
@@ -281,7 +281,7 @@ export class CodeyCommand extends SapphireCommand {
 
     if (isMessageInstance(initialMessageFromBot)) {
       try {
-        const successResponse = await commandDetails.executeCommand(client, interaction, initialMessageFromBot, args);
+        const successResponse = await commandDetails.executeCommand(client, interaction, args, initialMessageFromBot);
         switch (commandDetails.codeyCommandResponseType) {
           case CodeyCommandResponseType.EMBED:
             const currentChannel = (await client.channels.fetch(interaction.channelId)) as TextChannel;

--- a/src/codeyCommand.ts
+++ b/src/codeyCommand.ts
@@ -270,13 +270,12 @@ export class CodeyCommand extends SapphireCommand {
         .map((commandOption) => commandOption.name)
         .map((commandOptionName) => ({ [commandOptionName]: interaction.options.get(commandOptionName)?.value }))
     );
-    
+
     // Get subcommand name
     let subcommandName: string = '';
     try {
       subcommandName = interaction.options.getSubcommand();
-    }
-    catch (e: any) {}
+    } catch (e: any) {}
     /** The command details object to use */
     const commandDetails = this.details.subcommandDetails[subcommandName] ?? this.details;
 

--- a/src/codeyCommand.ts
+++ b/src/codeyCommand.ts
@@ -159,7 +159,6 @@ export class CodeyCommandDetails {
   /** A longer description of the command (shown in the help menu for the command) */
   detailedDescription: string = this.description;
 
-
   /** The message to display when the command is executing (for slash commands) */
   messageWhenExecutingCommand!: string;
   /** The function to be called to execute the command */
@@ -174,7 +173,7 @@ export class CodeyCommandDetails {
   /** Options for the Codey command */
   options: CodeyCommandOption[] = [];
   /** Subcommands under the CodeyCommand */
-  subcommandDetails: {[name: string]: CodeyCommandDetails} = {};
+  subcommandDetails: { [name: string]: CodeyCommandDetails } = {};
 }
 
 /** The codey command class */

--- a/src/codeyCommand.ts
+++ b/src/codeyCommand.ts
@@ -13,6 +13,8 @@ import { APIMessage } from 'discord-api-types/v9';
 import { isMessageInstance } from '@sapphire/discord.js-utilities';
 import {
   SlashCommandBuilder,
+  SlashCommandSubcommandBuilder,
+  SlashCommandSubcommandsOnlyBuilder,
   SlashCommandStringOption,
   SlashCommandIntegerOption,
   SlashCommandBooleanOption,
@@ -81,7 +83,7 @@ export interface CodeyCommandOption {
 }
 
 /** Sets the command option in the slash command builder */
-const setCommandOption = (builder: SlashCommandBuilder, option: CodeyCommandOption): SlashCommandBuilder => {
+const setCommandOption = (builder: SlashCommandBuilder | SlashCommandSubcommandBuilder, option: CodeyCommandOption): SlashCommandBuilder | SlashCommandSubcommandBuilder => {
   let commandOption: SlashCommandOption;
   switch (option.type) {
     case CodeyCommandOptionType.STRING:
@@ -176,6 +178,17 @@ export class CodeyCommandDetails {
   subcommandDetails: { [name: string]: CodeyCommandDetails } = {};
 }
 
+/** Sets the command subcommand in the slash command builder */
+const setCommandSubcommand = (builder: SlashCommandBuilder, subcommandDetails: CodeyCommandDetails): SlashCommandSubcommandsOnlyBuilder => {
+  const subcommandBuilder = new SlashCommandSubcommandBuilder();
+  subcommandBuilder.setName(subcommandDetails.name);
+  subcommandBuilder.setDescription(subcommandDetails.description);
+  for (const commandOption of subcommandDetails.options) {
+    setCommandOption(subcommandBuilder, commandOption);
+  }
+  return builder.addSubcommand(subcommandBuilder);
+}
+
 /** The codey command class */
 export class CodeyCommand extends SapphireCommand {
   /** The details of the command */
@@ -187,6 +200,9 @@ export class CodeyCommand extends SapphireCommand {
     builder.setDescription(this.details.description);
     for (const commandOption of this.details.options) {
       setCommandOption(builder, commandOption);
+    }
+    for (const subcommandName in this.details.subcommandDetails) {
+      setCommandSubcommand(builder, this.details.subcommandDetails[subcommandName]);
     }
     return builder;
   }

--- a/src/codeyCommand.ts
+++ b/src/codeyCommand.ts
@@ -64,6 +64,48 @@ const setCommandOption = (builder: SlashCommandBuilder, option: CodeyCommandOpti
       commandOption.setDescription(option.description);
       commandOption.setRequired(option.required);
       return <SlashCommandBuilder> builder.addIntegerOption(commandOption);
+    case CodeyCommandOptionType.BOOLEAN:
+      commandOption = new SlashCommandBooleanOption();
+      commandOption.setName(option.name);
+      commandOption.setDescription(option.description);
+      commandOption.setRequired(option.required);
+      return <SlashCommandBuilder> builder.addBooleanOption(commandOption);
+    case CodeyCommandOptionType.USER:
+      commandOption = new SlashCommandUserOption();
+      commandOption.setName(option.name);
+      commandOption.setDescription(option.description);
+      commandOption.setRequired(option.required);
+      return <SlashCommandBuilder> builder.addUserOption(commandOption);
+    case CodeyCommandOptionType.CHANNEL:
+      commandOption = new SlashCommandChannelOption();
+      commandOption.setName(option.name);
+      commandOption.setDescription(option.description);
+      commandOption.setRequired(option.required);
+      return <SlashCommandBuilder> builder.addChannelOption(commandOption);
+    case CodeyCommandOptionType.ROLE:
+      commandOption = new SlashCommandRoleOption();
+      commandOption.setName(option.name);
+      commandOption.setDescription(option.description);
+      commandOption.setRequired(option.required);
+      return <SlashCommandBuilder> builder.addRoleOption(commandOption);
+      case CodeyCommandOptionType.MENTIONABLE:
+        commandOption = new SlashCommandMentionableOption();
+        commandOption.setName(option.name);
+        commandOption.setDescription(option.description);
+        commandOption.setRequired(option.required);
+        return <SlashCommandBuilder> builder.addMentionableOption(commandOption);
+      case CodeyCommandOptionType.NUMBER:
+        commandOption = new SlashCommandNumberOption();
+        commandOption.setName(option.name);
+        commandOption.setDescription(option.description);
+        commandOption.setRequired(option.required);
+        return <SlashCommandBuilder> builder.addNumberOption(commandOption);
+        case CodeyCommandOptionType.ATTACHMENT:
+          commandOption = new SlashCommandAttachmentOption();
+          commandOption.setName(option.name);
+          commandOption.setDescription(option.description);
+          commandOption.setRequired(option.required);
+          return <SlashCommandBuilder> builder.addAttachmentOption(commandOption);
     default:
       throw new Error(`Unknown option type.`)
   }

--- a/src/codeyCommand.ts
+++ b/src/codeyCommand.ts
@@ -43,6 +43,7 @@ export enum CodeyCommandResponseType {
 }
 
 // Command options
+/** The type of the codey command option */
 export enum CodeyCommandOptionType {
   STRING = 'string',
   INTEGER = 'integer',
@@ -55,6 +56,7 @@ export enum CodeyCommandOptionType {
   ATTACHMENT = 'attachment'
 }
 
+/** We use this for convenience to put all the different types of SlashCommandOptions into one */
 type SlashCommandOption =
   | SlashCommandStringOption
   | SlashCommandIntegerOption
@@ -66,13 +68,19 @@ type SlashCommandOption =
   | SlashCommandNumberOption
   | SlashCommandAttachmentOption;
 
+/** The codey command option */
 export interface CodeyCommandOption {
+  /** The name of the option */
   name: string;
+  /** The description of the option */
   description: string;
+  /** The type of the option */
   type: CodeyCommandOptionType;
+  /** Whether the option is required */
   required: boolean;
 }
 
+/** Sets the command option in the slash command builder */
 const setCommandOption = (builder: SlashCommandBuilder, option: CodeyCommandOption): SlashCommandBuilder => {
   let commandOption: SlashCommandOption;
   switch (option.type) {
@@ -135,7 +143,9 @@ const setCommandOption = (builder: SlashCommandBuilder, option: CodeyCommandOpti
   }
 };
 
+/** The possible types of the value of a command option */
 export type CodeyCommandArgumentValueType = string | number | boolean | undefined;
+/** A standardized dictionary that stores the arguments of the command */
 export type CodeyCommandArguments = { [key: string]: CodeyCommandArgumentValueType };
 
 export class CodeyCommand extends SapphireCommand {

--- a/src/codeyCommand.ts
+++ b/src/codeyCommand.ts
@@ -83,7 +83,10 @@ export interface CodeyCommandOption {
 }
 
 /** Sets the command option in the slash command builder */
-const setCommandOption = (builder: SlashCommandBuilder | SlashCommandSubcommandBuilder, option: CodeyCommandOption): SlashCommandBuilder | SlashCommandSubcommandBuilder => {
+const setCommandOption = (
+  builder: SlashCommandBuilder | SlashCommandSubcommandBuilder,
+  option: CodeyCommandOption
+): SlashCommandBuilder | SlashCommandSubcommandBuilder => {
   let commandOption: SlashCommandOption;
   switch (option.type) {
     case CodeyCommandOptionType.STRING:
@@ -157,7 +160,7 @@ export class CodeyCommandDetails {
   /** The aliases of the command (for regular commands) */
   aliases: string[] = [];
   /** A short description of the command (shown in the slash command menu) */
-  description: string = `Codey command for ${this.name}`;
+  description = `Codey command for ${this.name}`;
   /** A longer description of the command (shown in the help menu for the command) */
   detailedDescription: string = this.description;
 
@@ -166,9 +169,9 @@ export class CodeyCommandDetails {
   /** The function to be called to execute the command */
   executeCommand!: SapphireMessageExecuteType;
   /** The message to display if the command fails */
-  messageIfFailure: string = 'Codey backend error - contact a mod for assistance';
+  messageIfFailure = 'Codey backend error - contact a mod for assistance';
   /** A flag to indicate if the command response is ephemeral (ie visible to others) */
-  isCommandResponseEphemeral: boolean = true;
+  isCommandResponseEphemeral = true;
   /** Type of response the Codey command sends */
   codeyCommandResponseType: CodeyCommandResponseType = CodeyCommandResponseType.STRING;
 
@@ -179,7 +182,10 @@ export class CodeyCommandDetails {
 }
 
 /** Sets the command subcommand in the slash command builder */
-const setCommandSubcommand = (builder: SlashCommandBuilder, subcommandDetails: CodeyCommandDetails): SlashCommandSubcommandsOnlyBuilder => {
+const setCommandSubcommand = (
+  builder: SlashCommandBuilder,
+  subcommandDetails: CodeyCommandDetails
+): SlashCommandSubcommandsOnlyBuilder => {
   const subcommandBuilder = new SlashCommandSubcommandBuilder();
   subcommandBuilder.setName(subcommandDetails.name);
   subcommandBuilder.setDescription(subcommandDetails.description);
@@ -187,7 +193,7 @@ const setCommandSubcommand = (builder: SlashCommandBuilder, subcommandDetails: C
     setCommandOption(subcommandBuilder, commandOption);
   }
   return builder.addSubcommand(subcommandBuilder);
-}
+};
 
 /** The codey command class */
 export class CodeyCommand extends SapphireCommand {
@@ -232,9 +238,9 @@ export class CodeyCommand extends SapphireCommand {
       );
     }
 
-    let subcommandName = message.content.split(' ')[1];
+    const subcommandName = message.content.split(' ')[1];
     /** The command details object to use */
-    let commandDetails = this.details.subcommandDetails[subcommandName] ?? this.details;
+    const commandDetails = this.details.subcommandDetails[subcommandName] ?? this.details;
 
     try {
       const successResponse = await commandDetails.executeCommand(client, message, initialMessageFromBot, args);
@@ -266,9 +272,9 @@ export class CodeyCommand extends SapphireCommand {
         .map((commandOption) => commandOption.name)
         .map((commandOptionName) => ({ [commandOptionName]: interaction.options.get(commandOptionName)?.value }))
     );
-    
+
     /** The command details object to use */
-    let commandDetails = this.details.subcommandDetails[interaction.options.getSubcommand()] ?? this.details;
+    const commandDetails = this.details.subcommandDetails[interaction.options.getSubcommand()] ?? this.details;
 
     if (isMessageInstance(initialMessageFromBot)) {
       try {

--- a/src/commands/fun/flipCoin.ts
+++ b/src/commands/fun/flipCoin.ts
@@ -1,6 +1,12 @@
 import { Command, container } from '@sapphire/framework';
 
-import { CodeyCommand, CodeyCommandDetails, CodeyCommandResponseType, SapphireMessageExecuteType, SapphireMessageResponse } from '../../codeyCommand';
+import {
+  CodeyCommand,
+  CodeyCommandDetails,
+  CodeyCommandResponseType,
+  SapphireMessageExecuteType,
+  SapphireMessageResponse
+} from '../../codeyCommand';
 
 const executeCommand: SapphireMessageExecuteType = (
   _client,
@@ -31,18 +37,18 @@ const flipcoinCommandDetails: CodeyCommandDetails = {
   codeyCommandResponseType: CodeyCommandResponseType.STRING,
 
   options: [],
-  subcommandDetails: {},
-}
+  subcommandDetails: {}
+};
 
 export class FunFlipCoinCommand extends CodeyCommand {
   details = flipcoinCommandDetails;
-  
+
   public constructor(context: Command.Context, options: Command.Options) {
     super(context, {
       ...options,
       aliases: flipcoinCommandDetails.aliases,
       description: flipcoinCommandDetails.description,
-      detailedDescription: flipcoinCommandDetails.detailedDescription,
+      detailedDescription: flipcoinCommandDetails.detailedDescription
     });
   }
 }

--- a/src/commands/fun/flipCoin.ts
+++ b/src/commands/fun/flipCoin.ts
@@ -2,7 +2,7 @@ import { Command, container } from '@sapphire/framework';
 
 import { CodeyCommand, SapphireMessageExecuteType, SapphireMessageResponse } from '../../codeyCommand';
 
-const commandOptions: Command.Options = {
+const commandDetails: Command.Options = {
   aliases: ['fc', 'flip', 'flip-coin', 'coin-flip', 'coinflip'],
   description: 'Flip a coin! In making decisions, if it is not great, at least it is fair!',
   detailedDescription: `**Examples:**
@@ -31,7 +31,7 @@ export class FunFlipCoinCommand extends CodeyCommand {
   public constructor(context: Command.Context, options: Command.Options) {
     super(context, {
       ...options,
-      ...commandOptions
+      ...commandDetails
     });
   }
 }

--- a/src/commands/fun/flipCoin.ts
+++ b/src/commands/fun/flipCoin.ts
@@ -1,18 +1,6 @@
 import { Command, container } from '@sapphire/framework';
 
-import { CodeyCommand, SapphireMessageExecuteType, SapphireMessageResponse } from '../../codeyCommand';
-
-const commandDetails: Command.Options = {
-  aliases: ['fc', 'flip', 'flip-coin', 'coin-flip', 'coinflip'],
-  description: 'Flip a coin! In making decisions, if it is not great, at least it is fair!',
-  detailedDescription: `**Examples:**
-\`${container.botPrefix}flip-coin\`
-\`${container.botPrefix}fc\`
-\`${container.botPrefix}flip\`
-\`${container.botPrefix}coin-flip\`
-\`${container.botPrefix}coinflip\`
-\`${container.botPrefix}flipcoin\``
-};
+import { CodeyCommand, CodeyCommandDetails, CodeyCommandResponseType, SapphireMessageExecuteType, SapphireMessageResponse } from '../../codeyCommand';
 
 const executeCommand: SapphireMessageExecuteType = (
   _client,
@@ -24,14 +12,37 @@ const executeCommand: SapphireMessageExecuteType = (
   return new Promise((resolve, _reject) => resolve(content));
 };
 
-export class FunFlipCoinCommand extends CodeyCommand {
-  messageWhenExecutingCommand = 'Flipping a coin...';
-  executeCommand: SapphireMessageExecuteType = executeCommand;
+const flipcoinCommandDetails: CodeyCommandDetails = {
+  name: 'flipCoin',
+  aliases: ['fc', 'flip', 'flip-coin', 'coin-flip', 'coinflip'],
+  description: 'Flip a coin! In making decisions, if it is not great, at least it is fair!',
+  detailedDescription: `**Examples:**
+\`${container.botPrefix}flip-coin\`
+\`${container.botPrefix}fc\`
+\`${container.botPrefix}flip\`
+\`${container.botPrefix}coin-flip\`
+\`${container.botPrefix}coinflip\`
+\`${container.botPrefix}flipcoin\``,
 
+  isCommandResponseEphemeral: true,
+  messageWhenExecutingCommand: 'Flipping a coin...',
+  executeCommand: executeCommand,
+  messageIfFailure: 'Failed to flip a coin.',
+  codeyCommandResponseType: CodeyCommandResponseType.STRING,
+
+  options: [],
+  subcommandDetails: {},
+}
+
+export class FunFlipCoinCommand extends CodeyCommand {
+  details = flipcoinCommandDetails;
+  
   public constructor(context: Command.Context, options: Command.Options) {
     super(context, {
       ...options,
-      ...commandDetails
+      aliases: flipcoinCommandDetails.aliases,
+      description: flipcoinCommandDetails.description,
+      detailedDescription: flipcoinCommandDetails.detailedDescription,
     });
   }
 }

--- a/src/commands/fun/flipCoin.ts
+++ b/src/commands/fun/flipCoin.ts
@@ -11,6 +11,7 @@ import {
 const executeCommand: SapphireMessageExecuteType = (
   _client,
   _messageFromUser,
+  _args,
   _initialMessageFromBot
 ): Promise<SapphireMessageResponse> => {
   const onHeads = Math.random() < 0.5;

--- a/src/commands/fun/rollDice.ts
+++ b/src/commands/fun/rollDice.ts
@@ -2,6 +2,7 @@ import { Command, container } from '@sapphire/framework';
 import { CodeyCommand, CodeyCommandOptionType, SapphireMessageExecuteType, SapphireMessageResponse } from '../../codeyCommand';
 import { Message } from 'discord.js';
 import { isInteger } from 'lodash';
+import { isConstructorDeclaration } from 'typescript';
 
 const commandDetails: Command.Options = {
   aliases: ['rd', 'roll', 'roll-dice', 'dice-roll', 'diceroll', 'dice'],

--- a/src/commands/fun/rollDice.ts
+++ b/src/commands/fun/rollDice.ts
@@ -15,8 +15,8 @@ const getRandomInt = (max: number): number => {
 const executeCommand: SapphireMessageExecuteType = (
   _client,
   _messageFromUser,
-  _initialMessageFromBot,
-  args
+  args,
+  _initialMessageFromBot
 ): Promise<SapphireMessageResponse> => {
   const SIDES_LOWER_BOUND = 0;
   const SIDES_UPPER_BOUND = 1000000;

--- a/src/commands/fun/rollDice.ts
+++ b/src/commands/fun/rollDice.ts
@@ -1,9 +1,9 @@
-import { ApplyOptions } from '@sapphire/decorators';
-import { Args, Command, CommandOptions, container } from '@sapphire/framework';
+import { Command, container } from '@sapphire/framework';
+import { CodeyCommand, CodeyCommandOptionType, SapphireMessageExecuteType, SapphireMessageResponse } from '../../codeyCommand';
 import { Message } from 'discord.js';
 import { isInteger } from 'lodash';
 
-@ApplyOptions<CommandOptions>({
+const commandDetails: Command.Options = {
   aliases: ['rd', 'roll', 'roll-dice', 'dice-roll', 'diceroll', 'dice'],
   description: 'Roll a dice!',
   detailedDescription: `**Examples:**
@@ -14,32 +14,47 @@ import { isInteger } from 'lodash';
 \`${container.botPrefix}diceroll 2\`
 \`${container.botPrefix}dice 1\`
 \`${container.botPrefix}rolldice 10\``
-})
-export class FunRollDiceCommand extends Command {
-  getRandomInt(max: number): number {
-    return Math.floor(Math.random() * max) + 1;
+};
+
+const getRandomInt = (max: number): number => {
+  return Math.floor(Math.random() * max) + 1;
+}
+
+const executeCommand: SapphireMessageExecuteType = (
+  _client,
+  _messageFromUser,
+  _initialMessageFromBot,
+  args
+): Promise<SapphireMessageResponse> => {
+  const SIDES_LOWER_BOUND = 0;
+  const SIDES_UPPER_BOUND = 1000000;
+  const sides = <number> args!["sides"];
+
+  if (sides <= SIDES_LOWER_BOUND) {
+    return new Promise((resolve, _reject) => resolve(`I cannot compute ${sides} sides!`));
   }
+  if (sides > SIDES_UPPER_BOUND) {
+    return new Promise((resolve, _reject) => resolve("that's too many sides!"));
+  }
+  const diceFace = getRandomInt(sides);
+  return new Promise((resolve, _reject) => resolve(`you rolled a ${diceFace}!`));
+}
 
-  async messageRun(message: Message, args: Args): Promise<Message> {
-    const SIDES_LOWER_BOUND = 0;
-    const SIDES_UPPER_BOUND = 1000000;
-    const sides = await args.pick('integer').catch(() => 6);
+export class FunRollDiceCommand extends CodeyCommand {
+  messageWhenExecutingCommand = "Rolling a die...";
+  executeCommand: SapphireMessageExecuteType = executeCommand;
 
-    //Argument enforcement
-    if (!isInteger(sides) || !args.finished) {
-      return message.reply(
-        `Invalid Parameters! Usage: \`rolldice <sides>\` \n` +
-          `\`sides\` - The number of sides on the dice you wish to roll, ` +
-          `must be \`${SIDES_LOWER_BOUND} < sides <= ${SIDES_UPPER_BOUND}\``
-      );
-    }
-    if (sides <= SIDES_LOWER_BOUND) {
-      return message.reply(`I cannot compute ${sides} sides!`);
-    }
-    if (sides > SIDES_UPPER_BOUND) {
-      return message.reply("that's too many sides!");
-    }
-    const diceFace = this.getRandomInt(sides);
-    return message.reply(`you rolled a ${diceFace}!`);
+  commandOptions = [{
+    name: "sides",
+    description: "The number of sides on the dice",
+    required: true,
+    type: CodeyCommandOptionType.INTEGER,
+  }]
+
+  public constructor(context: Command.Context, options: Command.Options) {
+    super(context, {
+      ...options,
+      ...commandDetails
+    });
   }
 }

--- a/src/commands/fun/rollDice.ts
+++ b/src/commands/fun/rollDice.ts
@@ -1,23 +1,12 @@
 import { Command, container } from '@sapphire/framework';
 import {
   CodeyCommand,
+  CodeyCommandDetails,
   CodeyCommandOptionType,
+  CodeyCommandResponseType,
   SapphireMessageExecuteType,
   SapphireMessageResponse
 } from '../../codeyCommand';
-
-const commandDetails: Command.Options = {
-  aliases: ['rd', 'roll', 'roll-dice', 'dice-roll', 'diceroll', 'dice'],
-  description: 'Roll a dice!',
-  detailedDescription: `**Examples:**
-\`${container.botPrefix}roll-dice 6\`
-\`${container.botPrefix}dice-roll 30\`
-\`${container.botPrefix}roll 100\`
-\`${container.botPrefix}rd 4\`
-\`${container.botPrefix}diceroll 2\`
-\`${container.botPrefix}dice 1\`
-\`${container.botPrefix}rolldice 10\``
-};
 
 const getRandomInt = (max: number): number => {
   return Math.floor(Math.random() * max) + 1;
@@ -43,23 +32,45 @@ const executeCommand: SapphireMessageExecuteType = (
   return new Promise((resolve, _reject) => resolve(`you rolled a ${diceFace}!`));
 };
 
-export class FunRollDiceCommand extends CodeyCommand {
-  messageWhenExecutingCommand = 'Rolling a die...';
-  executeCommand: SapphireMessageExecuteType = executeCommand;
+const rollDiceCommandDetails: CodeyCommandDetails = {
+  name: 'rollDice',
+  aliases: ['rd', 'roll', 'roll-dice', 'dice-roll', 'diceroll', 'dice'],
+  description: 'Roll a dice!',
+  detailedDescription: `**Examples:**
+\`${container.botPrefix}roll-dice 6\`
+\`${container.botPrefix}dice-roll 30\`
+\`${container.botPrefix}roll 100\`
+\`${container.botPrefix}rd 4\`
+\`${container.botPrefix}diceroll 2\`
+\`${container.botPrefix}dice 1\`
+\`${container.botPrefix}rolldice 10\``,
 
-  commandOptions = [
+  isCommandResponseEphemeral: true,
+  messageWhenExecutingCommand: 'Rolling a die...',
+  executeCommand: executeCommand,
+  messageIfFailure: 'Failed to roll a dice.',
+  codeyCommandResponseType: CodeyCommandResponseType.STRING,
+
+  options: [
     {
       name: 'sides',
       description: 'The number of sides on the dice',
       required: true,
       type: CodeyCommandOptionType.INTEGER
     }
-  ];
+  ],
+  subcommandDetails: {}
+};
+
+export class FunRollDiceCommand extends CodeyCommand {
+  details = rollDiceCommandDetails;
 
   public constructor(context: Command.Context, options: Command.Options) {
     super(context, {
       ...options,
-      ...commandDetails
+      aliases: rollDiceCommandDetails.aliases,
+      description: rollDiceCommandDetails.description,
+      detailedDescription: rollDiceCommandDetails.detailedDescription
     });
   }
 }

--- a/src/commands/fun/rollDice.ts
+++ b/src/commands/fun/rollDice.ts
@@ -1,8 +1,10 @@
 import { Command, container } from '@sapphire/framework';
-import { CodeyCommand, CodeyCommandOptionType, SapphireMessageExecuteType, SapphireMessageResponse } from '../../codeyCommand';
-import { Message } from 'discord.js';
-import { isInteger } from 'lodash';
-import { isConstructorDeclaration } from 'typescript';
+import {
+  CodeyCommand,
+  CodeyCommandOptionType,
+  SapphireMessageExecuteType,
+  SapphireMessageResponse
+} from '../../codeyCommand';
 
 const commandDetails: Command.Options = {
   aliases: ['rd', 'roll', 'roll-dice', 'dice-roll', 'diceroll', 'dice'],
@@ -19,7 +21,7 @@ const commandDetails: Command.Options = {
 
 const getRandomInt = (max: number): number => {
   return Math.floor(Math.random() * max) + 1;
-}
+};
 
 const executeCommand: SapphireMessageExecuteType = (
   _client,
@@ -29,7 +31,7 @@ const executeCommand: SapphireMessageExecuteType = (
 ): Promise<SapphireMessageResponse> => {
   const SIDES_LOWER_BOUND = 0;
   const SIDES_UPPER_BOUND = 1000000;
-  const sides = <number> args!["sides"];
+  const sides = <number>args!['sides'];
 
   if (sides <= SIDES_LOWER_BOUND) {
     return new Promise((resolve, _reject) => resolve(`I cannot compute ${sides} sides!`));
@@ -39,18 +41,20 @@ const executeCommand: SapphireMessageExecuteType = (
   }
   const diceFace = getRandomInt(sides);
   return new Promise((resolve, _reject) => resolve(`you rolled a ${diceFace}!`));
-}
+};
 
 export class FunRollDiceCommand extends CodeyCommand {
-  messageWhenExecutingCommand = "Rolling a die...";
+  messageWhenExecutingCommand = 'Rolling a die...';
   executeCommand: SapphireMessageExecuteType = executeCommand;
 
-  commandOptions = [{
-    name: "sides",
-    description: "The number of sides on the dice",
-    required: true,
-    type: CodeyCommandOptionType.INTEGER,
-  }]
+  commandOptions = [
+    {
+      name: 'sides',
+      description: 'The number of sides on the dice',
+      required: true,
+      type: CodeyCommandOptionType.INTEGER
+    }
+  ];
 
   public constructor(context: Command.Context, options: Command.Options) {
     super(context, {

--- a/src/commands/info/info.ts
+++ b/src/commands/info/info.ts
@@ -2,6 +2,7 @@ import { Command, container } from '@sapphire/framework';
 import { MessageEmbed } from 'discord.js';
 import {
   CodeyCommand,
+  CodeyCommandDetails,
   CodeyCommandResponseType,
   SapphireMessageExecuteType,
   SapphireMessageResponse
@@ -22,7 +23,7 @@ export const getInfoEmbed = async (): Promise<MessageEmbed> => {
     .setURL(githubRepositoryInfo.html_url)
     .setThumbnail(githubRepositoryInfo.owner.avatar_url)
     .setDescription('Links to issue templates: https://github.com/uwcsc/codeybot/tree/master/.github/ISSUE_TEMPLATE')
-    .setFooter(`App version: ${githubRepositoryReleases[0].tag_name}`); // I have no idea where to find this
+    .setFooter(`App version: ${githubRepositoryReleases[0].tag_name}`);
   return infoEmbed;
 };
 
@@ -35,18 +36,32 @@ const executeCommand: SapphireMessageExecuteType = async (
   return infoEmbed;
 };
 
+const infoCommandDetails: CodeyCommandDetails = {
+  name: 'info',
+  aliases: [],
+  description: 'Get Codey information - app version, repository link and issue templates',
+  detailedDescription: `**Examples:**
+  \`${container.botPrefix}info\``,
+
+  isCommandResponseEphemeral: false,
+  messageWhenExecutingCommand: 'Getting Codey Info...',
+  messageIfFailure: 'Could not get Codey info.',
+  executeCommand: executeCommand,
+  codeyCommandResponseType: CodeyCommandResponseType.EMBED,
+
+  options: [],
+  subcommandDetails: {},
+}
+
 export class InfoCommand extends CodeyCommand {
-  messageWhenExecutingCommand = 'Fetching Codey info:';
-  executeCommand: SapphireMessageExecuteType = executeCommand;
-  isCommandResponseEphemeral = false;
-  codeyCommandResponseType = CodeyCommandResponseType.EMBED;
+  details = infoCommandDetails;
 
   public constructor(context: Command.Context, options: Command.Options) {
     super(context, {
       ...options,
-      description: 'Fetches Codey information - app version, repository link and issue templates',
-      detailedDescription: `**Examples:**
-        \`${container.botPrefix}info\``
+      aliases: infoCommandDetails.aliases,
+      description: infoCommandDetails.description,
+      detailedDescription: infoCommandDetails.detailedDescription,
     });
   }
 }

--- a/src/commands/info/info.ts
+++ b/src/commands/info/info.ts
@@ -50,8 +50,8 @@ const infoCommandDetails: CodeyCommandDetails = {
   codeyCommandResponseType: CodeyCommandResponseType.EMBED,
 
   options: [],
-  subcommandDetails: {},
-}
+  subcommandDetails: {}
+};
 
 export class InfoCommand extends CodeyCommand {
   details = infoCommandDetails;
@@ -61,7 +61,7 @@ export class InfoCommand extends CodeyCommand {
       ...options,
       aliases: infoCommandDetails.aliases,
       description: infoCommandDetails.description,
-      detailedDescription: infoCommandDetails.detailedDescription,
+      detailedDescription: infoCommandDetails.detailedDescription
     });
   }
 }

--- a/src/commands/info/info.ts
+++ b/src/commands/info/info.ts
@@ -30,6 +30,7 @@ export const getInfoEmbed = async (): Promise<MessageEmbed> => {
 const executeCommand: SapphireMessageExecuteType = async (
   _client,
   _messageFromUser,
+  _args,
   _initialMessageFromBot
 ): Promise<SapphireMessageResponse> => {
   const infoEmbed = await getInfoEmbed();

--- a/src/commands/miscellaneous/help.ts
+++ b/src/commands/miscellaneous/help.ts
@@ -12,6 +12,7 @@ const wikiLink = 'https://github.com/uwcsc/codeybot/wiki/Command-Help';
 const executeCommand: SapphireMessageExecuteType = (
   _client,
   _messageFromUser,
+  _args,
   _initialMessageFromBot
 ): Promise<SapphireMessageResponse> => {
   return new Promise((resolve, _reject) => resolve(`<${wikiLink}>`));

--- a/src/commands/miscellaneous/help.ts
+++ b/src/commands/miscellaneous/help.ts
@@ -1,15 +1,13 @@
 import { Command, container } from '@sapphire/framework';
-import { CodeyCommand, SapphireMessageExecuteType, SapphireMessageResponse } from '../../codeyCommand';
+import {
+  CodeyCommand,
+  CodeyCommandDetails,
+  CodeyCommandResponseType,
+  SapphireMessageExecuteType,
+  SapphireMessageResponse
+} from '../../codeyCommand';
 
-const wikiLink = 'https://github.com/uwcsc/codeybot/wiki/Command-Help:';
-
-const commandOptions: Command.Options = {
-  aliases: ['wiki'],
-  description: 'Provides the URL to the wiki page.',
-  detailedDescription: `**Examples:**
-\`${container.botPrefix}help\`
-\`${container.botPrefix}wiki\``
-};
+const wikiLink = 'https://github.com/uwcsc/codeybot/wiki/Command-Help';
 
 const executeCommand: SapphireMessageExecuteType = (
   _client,
@@ -19,14 +17,33 @@ const executeCommand: SapphireMessageExecuteType = (
   return new Promise((resolve, _reject) => resolve(`<${wikiLink}>`));
 };
 
+const helpCommandDetails: CodeyCommandDetails = {
+  name: 'help',
+  aliases: ['wiki'],
+  description: 'Provides the URL to the wiki page.',
+  detailedDescription: `**Examples:**
+\`${container.botPrefix}help\`
+\`${container.botPrefix}wiki\``,
+
+  isCommandResponseEphemeral: false,
+  messageWhenExecutingCommand: 'Retrieving URL to the wiki page...',
+  executeCommand: executeCommand,
+  messageIfFailure: 'Could not retrieve URL to the wiki page.',
+  codeyCommandResponseType: CodeyCommandResponseType.STRING,
+
+  options: [],
+  subcommandDetails: {}
+};
+
 export class MiscellaneousHelpCommand extends CodeyCommand {
-  messageWhenExecutingCommand = 'Retrieving URL to the wiki page...';
-  executeCommand: SapphireMessageExecuteType = executeCommand;
+  details = helpCommandDetails;
 
   public constructor(context: Command.Context, options: Command.Options) {
     super(context, {
       ...options,
-      ...commandOptions
+      aliases: helpCommandDetails.aliases,
+      description: helpCommandDetails.description,
+      detailedDescription: helpCommandDetails.detailedDescription
     });
   }
 }

--- a/src/commands/ping/ping.ts
+++ b/src/commands/ping/ping.ts
@@ -22,8 +22,8 @@ const content = (botLatency: number, apiLatency: number) =>
 const executeCommand: SapphireMessageExecuteType = async (
   client,
   messageFromUser,
-  initialMessageFromBot,
-  _args
+  _args,
+  initialMessageFromBot
 ): Promise<SapphireMessageResponse> => {
   // Assert message types are Message<boolean>
   // We have to do this because APIMessage does not have "createdTimestamp" property

--- a/src/commands/ping/ping.ts
+++ b/src/commands/ping/ping.ts
@@ -1,6 +1,12 @@
 import { Command, container } from '@sapphire/framework';
 import { Message } from 'discord.js';
-import { CodeyCommand, CodeyCommandDetails, CodeyCommandResponseType, SapphireMessageExecuteType, SapphireMessageResponse } from '../../codeyCommand';
+import {
+  CodeyCommand,
+  CodeyCommandDetails,
+  CodeyCommandResponseType,
+  SapphireMessageExecuteType,
+  SapphireMessageResponse
+} from '../../codeyCommand';
 
 const executeCommand: SapphireMessageExecuteType = (
   client,
@@ -32,8 +38,8 @@ const pingCommandDetails: CodeyCommandDetails = {
   codeyCommandResponseType: CodeyCommandResponseType.STRING,
 
   options: [],
-  subcommandDetails: {},
-}
+  subcommandDetails: {}
+};
 
 export class PingCommand extends CodeyCommand {
   details = pingCommandDetails;
@@ -43,7 +49,7 @@ export class PingCommand extends CodeyCommand {
       ...options,
       aliases: pingCommandDetails.aliases,
       description: pingCommandDetails.description,
-      detailedDescription: pingCommandDetails.detailedDescription,
+      detailedDescription: pingCommandDetails.detailedDescription
     });
   }
 }

--- a/src/commands/ping/ping.ts
+++ b/src/commands/ping/ping.ts
@@ -23,6 +23,72 @@ const executeCommand: SapphireMessageExecuteType = (
   return new Promise((resolve, _reject) => resolve(content));
 };
 
+const executeCommand1: SapphireMessageExecuteType = (
+  client,
+  messageFromUser,
+  initialMessageFromBot
+): Promise<SapphireMessageResponse> => {
+  // Assert message types are Message<boolean>
+  // We have to do this because APIMessage does not have "createdTimestamp" property
+  const messageFromUserAsMessage = <Message<boolean>>messageFromUser;
+  const initialMessageFromBotAsMessage = <Message<boolean>>initialMessageFromBot;
+  const botLatency = client.ws.ping;
+  const apiLatency = initialMessageFromBotAsMessage.createdTimestamp - messageFromUserAsMessage.createdTimestamp;
+  const content = `Pong from JavaScript (1)! Bot Latency ${botLatency}ms. API Latency ${apiLatency}ms.`;
+  return new Promise((resolve, _reject) => resolve(content));
+};
+
+const pingCommand1Details: CodeyCommandDetails = {
+  name: 'one',
+  aliases: [],
+  description: 'Ping the bot to see if it is alive. Subcommand 1',
+  detailedDescription: `**Examples:**
+    \`${container.botPrefix}ping\`
+    \`${container.botPrefix}pong\``,
+
+  isCommandResponseEphemeral: true,
+  messageWhenExecutingCommand: 'Ping?',
+  messageIfFailure: 'Failed to receive ping.',
+  executeCommand: executeCommand1,
+  codeyCommandResponseType: CodeyCommandResponseType.STRING,
+
+  options: [],
+  subcommandDetails: {}
+};
+
+const executeCommand2: SapphireMessageExecuteType = (
+  client,
+  messageFromUser,
+  initialMessageFromBot
+): Promise<SapphireMessageResponse> => {
+  // Assert message types are Message<boolean>
+  // We have to do this because APIMessage does not have "createdTimestamp" property
+  const messageFromUserAsMessage = <Message<boolean>>messageFromUser;
+  const initialMessageFromBotAsMessage = <Message<boolean>>initialMessageFromBot;
+  const botLatency = client.ws.ping;
+  const apiLatency = initialMessageFromBotAsMessage.createdTimestamp - messageFromUserAsMessage.createdTimestamp;
+  const content = `Pong from JavaScript (2)! Bot Latency ${botLatency}ms. API Latency ${apiLatency}ms.`;
+  return new Promise((resolve, _reject) => resolve(content));
+};
+
+const pingCommand2Details: CodeyCommandDetails = {
+  name: 'two',
+  aliases: [],
+  description: 'Ping the bot to see if it is alive. Subcommand 2',
+  detailedDescription: `**Examples:**
+    \`${container.botPrefix}ping\`
+    \`${container.botPrefix}pong\``,
+
+  isCommandResponseEphemeral: true,
+  messageWhenExecutingCommand: 'Ping?',
+  messageIfFailure: 'Failed to receive ping.',
+  executeCommand: executeCommand2,
+  codeyCommandResponseType: CodeyCommandResponseType.STRING,
+
+  options: [],
+  subcommandDetails: {}
+};
+
 const pingCommandDetails: CodeyCommandDetails = {
   name: 'ping',
   aliases: ['pong'],
@@ -38,7 +104,10 @@ const pingCommandDetails: CodeyCommandDetails = {
   codeyCommandResponseType: CodeyCommandResponseType.STRING,
 
   options: [],
-  subcommandDetails: {}
+  subcommandDetails: {
+    one: pingCommand1Details,
+    two: pingCommand2Details
+  }
 };
 
 export class PingCommand extends CodeyCommand {

--- a/src/commands/ping/ping.ts
+++ b/src/commands/ping/ping.ts
@@ -1,6 +1,6 @@
 import { Command, container } from '@sapphire/framework';
 import { Message } from 'discord.js';
-import { CodeyCommand, SapphireMessageExecuteType, SapphireMessageResponse } from '../../codeyCommand';
+import { CodeyCommand, CodeyCommandOptionType, SapphireMessageExecuteType, SapphireMessageResponse } from '../../codeyCommand';
 
 const executeCommand: SapphireMessageExecuteType = (
   client,
@@ -26,7 +26,7 @@ export class PingCommand extends CodeyCommand {
     super(context, {
       ...options,
       aliases: ['pong'],
-      description: 'ping pong',
+      description: 'Ping the bot to see if it is alive.',
       detailedDescription: `**Examples:**
         \`${container.botPrefix}ping\`
         \`${container.botPrefix}pong\``

--- a/src/commands/ping/ping.ts
+++ b/src/commands/ping/ping.ts
@@ -1,6 +1,6 @@
 import { Command, container } from '@sapphire/framework';
 import { Message } from 'discord.js';
-import { CodeyCommand, SapphireMessageExecuteType, SapphireMessageResponse } from '../../codeyCommand';
+import { CodeyCommand, CodeyCommandDetails, CodeyCommandResponseType, SapphireMessageExecuteType, SapphireMessageResponse } from '../../codeyCommand';
 
 const executeCommand: SapphireMessageExecuteType = (
   client,
@@ -17,19 +17,33 @@ const executeCommand: SapphireMessageExecuteType = (
   return new Promise((resolve, _reject) => resolve(content));
 };
 
+const pingCommandDetails: CodeyCommandDetails = {
+  name: 'ping',
+  aliases: ['pong'],
+  description: 'Ping the bot to see if it is alive.',
+  detailedDescription: `**Examples:**
+    \`${container.botPrefix}ping\`
+    \`${container.botPrefix}pong\``,
+
+  isCommandResponseEphemeral: true,
+  messageWhenExecutingCommand: 'Ping?',
+  messageIfFailure: 'Failed to receive ping.',
+  executeCommand: executeCommand,
+  codeyCommandResponseType: CodeyCommandResponseType.STRING,
+
+  options: [],
+  subcommandDetails: {},
+}
+
 export class PingCommand extends CodeyCommand {
-  messageWhenExecutingCommand = 'Ping?';
-  messageIfFailure = 'Failed to receive ping.';
-  executeCommand: SapphireMessageExecuteType = executeCommand;
+  details = pingCommandDetails;
 
   public constructor(context: Command.Context, options: Command.Options) {
     super(context, {
       ...options,
-      aliases: ['pong'],
-      description: 'Ping the bot to see if it is alive.',
-      detailedDescription: `**Examples:**
-        \`${container.botPrefix}ping\`
-        \`${container.botPrefix}pong\``
+      aliases: pingCommandDetails.aliases,
+      description: pingCommandDetails.description,
+      detailedDescription: pingCommandDetails.detailedDescription,
     });
   }
 }

--- a/src/commands/ping/ping.ts
+++ b/src/commands/ping/ping.ts
@@ -1,6 +1,6 @@
 import { Command, container } from '@sapphire/framework';
 import { Message } from 'discord.js';
-import { CodeyCommand, CodeyCommandOptionType, SapphireMessageExecuteType, SapphireMessageResponse } from '../../codeyCommand';
+import { CodeyCommand, SapphireMessageExecuteType, SapphireMessageResponse } from '../../codeyCommand';
 
 const executeCommand: SapphireMessageExecuteType = (
   client,


### PR DESCRIPTION
# Summary of Changes
- Added the options and subcommands functionalities into the CodeyCommand class
- Slashified the rollDice command (which requires options)
- Fixed a bug where slash commands would not be updated if they had already been registered

## Screenshots

### Options

**Regular command**
![image](https://user-images.githubusercontent.com/76544623/179054751-e7ddf363-a73f-433f-8045-16b908258fb6.png)

**Slash command**
![image](https://user-images.githubusercontent.com/76544623/179054832-a356582d-936e-4417-ab96-160812abce4f.png)
![image](https://user-images.githubusercontent.com/76544623/179054882-884cba3d-d333-40e4-880d-3028424e584f.png)

### Sub-Commands

**Regular command**
![image](https://user-images.githubusercontent.com/76544623/179375704-bc2e74de-6dac-45a7-b450-3ae008ee6cbf.png)

**Slash command**
![image](https://user-images.githubusercontent.com/76544623/179375731-4f421cba-daa6-4f4a-9079-a170420eca1e.png)

After using `/ping one`:
![image](https://user-images.githubusercontent.com/76544623/179375739-7eaa64ec-3c1e-4979-ac8b-c62f162250b4.png)

After using `/ping two`:
![image](https://user-images.githubusercontent.com/76544623/179375748-8cc9f70b-4e31-45ef-985b-d439a5d39fff.png)

## Notes
- The slash command parameter is type-enforced and required. In other words, you need to put in a sides parameter in order to run the command, and said parameter must be an integer.
- The `ping one` and `ping two` commands are only placeholders to verify that simple subcommands work. My next step will be to slashify coin - when I have done this, I will replace the ping back with the "original" command and show the coin screenshots instead.