### PR TITLE
enable profile about to default to self profile

### DIFF
--- a/src/commands/profile/profile.ts
+++ b/src/commands/profile/profile.ts
@@ -24,8 +24,7 @@ import { EMBED_COLOUR } from '../../utils/embeds';
 })
 export class ProfileCommand extends SubCommandPluginCommand {
   public async about(message: Message, args: Args): Promise<Message> {
-    const user = await args.rest('user').catch(() => 'please enter a valid user mention or ID to check their profile.');
-    if (typeof user === 'string') return message.reply(user);
+    const user = await args.rest('user').catch(() => message.author);
     // get user profile if exists
     const profileDetails: UserProfile | undefined = await getUserProfileById(user.id);
     if (!profileDetails) {


### PR DESCRIPTION
`.profile` has always felt more intuitive if it shows the caller's profile by default, this issue implements that.
![image](https://user-images.githubusercontent.com/39033120/179366356-c24aba26-186d-4b5b-ac8d-aa629b54282e.png)

