### PR TITLE
Small fixes to slash commands, refactored flipcoin/rolldice

### DIFF
--- a/src/commands/fun/flipCoin.ts
+++ b/src/commands/fun/flipCoin.ts
@@ -20,7 +20,7 @@ const executeCommand: SapphireMessageExecuteType = (
 };
 
 const flipcoinCommandDetails: CodeyCommandDetails = {
-  name: 'flipCoin',
+  name: 'flipcoin',
   aliases: ['fc', 'flip', 'flip-coin', 'coin-flip', 'coinflip'],
   description: 'Flip a coin! In making decisions, if it is not great, at least it is fair!',
   detailedDescription: `**Examples:**

--- a/src/commands/fun/rollDice.ts
+++ b/src/commands/fun/rollDice.ts
@@ -33,7 +33,7 @@ const executeCommand: SapphireMessageExecuteType = (
 };
 
 const rollDiceCommandDetails: CodeyCommandDetails = {
-  name: 'rollDice',
+  name: 'rolldice',
   aliases: ['rd', 'roll', 'roll-dice', 'dice-roll', 'diceroll', 'dice'],
   description: 'Roll a dice!',
   detailedDescription: `**Examples:**


### PR DESCRIPTION
Made some small fixes to bugs I found after merging the previous slash commands PR.

Also, TS was complaining that the commands "flipCoin" and "rollDice" should be named lower-case, not camel case, so I've made this change accordingly.