### PR TITLE
setup local dev and staging to use yarn

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,13 @@
-FROM node:16-alpine
+FROM node:18-alpine
 
 # Create app directory
 WORKDIR /usr/app
 
 # Install app dependencies
-COPY package.json .
-RUN npm install
+COPY package.json yarn.lock ./
+RUN yarn --frozen-lockfile
 
 # Copy app files
 COPY . .
 
-CMD [ "npm", "run", "local:run" ]
+CMD [ "yarn", "run", "local:run" ]

--- a/docker/staging/Dockerfile
+++ b/docker/staging/Dockerfile
@@ -1,19 +1,21 @@
 # Stage 1: Typescript build app
-FROM node:16-alpine AS ts-build
+FROM node:18-alpine AS ts-build
 WORKDIR /usr/app
-COPY package.json .
-RUN npm install
+COPY package.json yarn.lock ./
+RUN yarn --frozen-lockfile
 COPY . .
-RUN npm run ts:build
+RUN yarn run ts:build
 
 # Stage 2: Run in staging env
-FROM node:16-alpine
+FROM node:18-alpine
 WORKDIR /usr/app
 ENV NODE_ENV="staging"
-COPY package.json .
-RUN npm install --only=production
-RUN npm install pm2 -g
-COPY . .
+COPY package.json yarn.lock ./
+RUN yarn --frozen-lockfile --prod
+RUN yarn global add pm2
 COPY --from=ts-build /usr/app/dist ./dist
+COPY ./config ./config
+COPY ./db ./db
+COPY ./logs ./logs
 
 CMD [ "pm2-runtime", "--raw", "./dist/index.js" ]


### PR DESCRIPTION
Change dockerfiles for local and staging environments to use yarn instead of node for consistency.

Update dockerfiles to use alpine 18 to prevent compatibility issues.

Once this is pushed, the same dockerfile should work for production with no extra problem.

Dockerfile tested to work in local production, waiting on staging to verify.