### PR TITLE
Fix aliases for subcommands

### DIFF
--- a/src/codeyCommand.ts
+++ b/src/codeyCommand.ts
@@ -225,10 +225,20 @@ export class CodeyCommand extends SapphireCommand {
     /** The command details object to use */
     let commandDetails = this.details.subcommandDetails[subcommandName];
     if (!commandDetails) {
-      if (this.details.subcommandDetails !== {}) {
-        commandDetails = this.details.defaultSubcommandDetails!;
-      } else {
-        commandDetails = this.details;
+      // Check whether the subcommand is an alias of another command
+      for (const subcommandDetail of Object.values(this.details.subcommandDetails)) {
+        if (subcommandDetail.aliases.includes(subcommandName)) {
+          commandDetails = subcommandDetail;
+          break;
+        }
+      }
+      // If the subcommand is not an alias of another subcommand, use the default
+      if (!commandDetails) {
+        if (this.details.subcommandDetails !== {}) {
+          commandDetails = this.details.defaultSubcommandDetails!;
+        } else {
+          commandDetails = this.details;
+        }
       }
     }
 


### PR DESCRIPTION
# Summary of Changes
Fixed aliases for subcommands. This fix is only relevant for regular commands (slash commands don't need aliases.)

## Screenshots

![image](https://user-images.githubusercontent.com/76544623/183309337-8c73c798-33a8-4d49-ae57-86a6c8504753.png)
