### PR TITLE
Fixed local:run script to create tmp directory

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "dist/src/bot.js",
   "scripts": {
-    "local:run": "NODE_ENV=dev tsc-watch --onSuccess \"node dist/index.js\"",
+    "local:run": "mkdir -p tmp && NODE_ENV=dev tsc-watch --onSuccess \"node dist/index.js\"",
     "ts:build": "tsc",
     "image:build": "docker build . -t codey",
     "clean": "docker-compose down",


### PR DESCRIPTION
# Related Issues
<!-- Issue(s) that this PR will resolve, e.g. "resolves <issue link here>". -->
Resolves #285 

# Summary of Changes
<!-- A summary or description of changes made in this PR. -->
Added `mkdir -p tmp` to the local:run script to make the tmp directory

# Steps to Reproduce
<!-- List the steps needed for the reviewer to produce your PR changes.
     If possible, also include screenshots to illustrate your new feature or fix. -->
When running the bot locally, see that the tmp directory is created if non-existent and no error is thrown if already existent. In addition, resume previews should now work.
![image](https://user-images.githubusercontent.com/58180935/184517258-71c372f0-a6a6-4e60-b6ed-7e00ad5dda38.png)
