### PR TITLE
feat(coin): Use current user if no argument is passed to the "check" subcommand

### DIFF
--- a/src/commandDetails/coin/check.ts
+++ b/src/commandDetails/coin/check.ts
@@ -17,7 +17,7 @@ const coinCheckExecuteCommand: SapphireMessageExecuteType = async (
   args
 ): Promise<SapphireMessageResponse> => {
   // Mandatory argument is user
-  const user = <User>args['user'];
+  const user = <User>args['user'] ?? _messageFromUser.member!.user;
   // Get coin balance
   let balance: number;
   try {
@@ -47,7 +47,7 @@ export const coinCheckCommandDetails: CodeyCommandDetails = {
       name: 'user',
       description: 'The user to check the balance of,',
       type: CodeyCommandOptionType.USER,
-      required: true
+      required: false
     }
   ],
   subcommandDetails: {}


### PR DESCRIPTION
# Related Issues
None.

# Summary of Changes
Instead of enforcing the `user` argument on the `/coin check` subcommand, consider the command executor (author).
I'm open to better methods of fetching the command executor.

# Steps to Reproduce
`/coin check`

![image](https://user-images.githubusercontent.com/63275405/184558539-54eba8ff-8f0a-4d1a-80a7-e83b7c92286f.png)
