### PR TITLE
Move info and ping commands to miscellaneous dir

### DIFF
--- a/src/commands/miscellaneous/info.ts
+++ b/src/commands/miscellaneous/info.ts
@@ -54,7 +54,7 @@ const infoCommandDetails: CodeyCommandDetails = {
   subcommandDetails: {}
 };
 
-export class MiscellaneousCommand extends CodeyCommand {
+export class MiscellaneousInfoCommand extends CodeyCommand {
   details = infoCommandDetails;
 
   public constructor(context: Command.Context, options: Command.Options) {

--- a/src/commands/miscellaneous/info.ts
+++ b/src/commands/miscellaneous/info.ts
@@ -54,7 +54,7 @@ const infoCommandDetails: CodeyCommandDetails = {
   subcommandDetails: {}
 };
 
-export class InfoCommand extends CodeyCommand {
+export class MiscellaneousCommand extends CodeyCommand {
   details = infoCommandDetails;
 
   public constructor(context: Command.Context, options: Command.Options) {

--- a/src/commands/miscellaneous/ping.ts
+++ b/src/commands/miscellaneous/ping.ts
@@ -57,7 +57,7 @@ const pingCommandDetails: CodeyCommandDetails = {
   subcommandDetails: {}
 };
 
-export class PingCommand extends CodeyCommand {
+export class MiscellaneousPingCommand extends CodeyCommand {
   details = pingCommandDetails;
 
   public constructor(context: Command.Context, options: Command.Options) {


### PR DESCRIPTION
## Summary of Changes
Move info and ping into miscellaneous folder. Prefix the command class with Miscellaneous.

## Related Issues
https://github.com/uwcsc/codeybot/issues/303

## Steps to Reproduce
Confirm .info and .ping work as expected.

## Demonstration of Changes
Info and ping work as intended. No change in output.