### PR TITLE
automate year and alumni roles

### DIFF
--- a/src/commands/profile/profile.ts
+++ b/src/commands/profile/profile.ts
@@ -14,8 +14,7 @@ import {
   validCustomizations,
   validCustomizationsDisplay,
   validUserCustomization,
-  prettyProfileDetails,
-  updateProfileRoles
+  prettyProfileDetails
 } from '../../components/profile';
 import { EMBED_COLOUR } from '../../utils/embeds';
 

--- a/src/commands/profile/profile.ts
+++ b/src/commands/profile/profile.ts
@@ -14,7 +14,7 @@ import {
   validCustomizations,
   validCustomizationsDisplay,
   validUserCustomization,
-  prettyProfileDetails
+  prettyProfileDetails,
 } from '../../components/profile';
 import { EMBED_COLOUR } from '../../utils/embeds';
 
@@ -82,7 +82,9 @@ export class ProfileCommand extends SubCommandPluginCommand {
     }
     const { reason, parsedDescription } = validUserCustomization(customization, description);
     if (reason === 'valid' && message.member) {
-      editUserProfile(message.member, { [configMaps[customization]]: parsedDescription } as UserProfile);
+      editUserProfile(message.member, {
+        [configMaps[customization]]: parsedDescription,
+      } as UserProfile);
       return message.reply(`${customization} has been set!`);
     }
     // if reason is not valid the reason will be returned by the validUserCustomization function

--- a/src/commands/profile/profile.ts
+++ b/src/commands/profile/profile.ts
@@ -8,7 +8,7 @@ import { Message, MessageEmbed } from 'discord.js';
 import { getCoinBalanceByUserId } from '../../components/coin';
 import {
   configMaps,
-  editUserProfileById,
+  editUserProfile,
   getUserProfileById,
   UserProfile,
   validCustomizations,
@@ -69,7 +69,6 @@ export class ProfileCommand extends SubCommandPluginCommand {
   }
 
   public async set(message: Message, args: Args): Promise<Message> {
-    const { author } = message;
     const customization = <keyof typeof configMaps>await args.pick('string').catch(() => false);
     // if no customization is supplied, or its not one of the customizations we provide, return
     if (typeof customization === 'boolean' || !validCustomizations.includes(customization)) {
@@ -82,10 +81,8 @@ export class ProfileCommand extends SubCommandPluginCommand {
       return message.reply('Please enter a description.');
     }
     const { reason, parsedDescription } = validUserCustomization(customization, description);
-    if (reason === 'valid') {
-      editUserProfileById(author.id, {
-        [configMaps[customization]]: parsedDescription,
-      } as UserProfile);
+    if (reason === 'valid' && message.member) {
+      editUserProfile(message.member, { [configMaps[customization]]: parsedDescription } as UserProfile);
       return message.reply(`${customization} has been set!`);
     }
     // if reason is not valid the reason will be returned by the validUserCustomization function

--- a/src/commands/profile/profile.ts
+++ b/src/commands/profile/profile.ts
@@ -15,6 +15,7 @@ import {
   validCustomizationsDisplay,
   validUserCustomization,
   prettyProfileDetails,
+  updateProfileRoles
 } from '../../components/profile';
 import { EMBED_COLOUR } from '../../utils/embeds';
 

--- a/src/components/profile.ts
+++ b/src/components/profile.ts
@@ -179,7 +179,7 @@ export const editUserProfile = async (member: GuildMember, data: UserProfile): P
   const [customization, description] = Object.entries(data)[0];
 
   if (customization === 'year') {
-    // onlyDescription here would be the new year role
+    // description here would be the new year role
     await updateMemberGradRoles(member, description);
   }
 

--- a/src/components/profile.ts
+++ b/src/components/profile.ts
@@ -1,4 +1,7 @@
 import { openDB } from './db';
+import { container } from '@sapphire/framework';
+import { ColorResolvable, Message } from "discord.js";
+import { getUserFromMessage } from '../codeyCommand';
 
 export interface UserProfile {
   about_me?: string;
@@ -29,7 +32,14 @@ const validTerms: string[] = [
   'Professor',
 ];
 const yearStart = 1900;
-const yearEnd = new Date().getFullYear() + 7;
+const currentYear = new Date().getFullYear()
+// the last valid year of graduation in the future. while most people graduate in <5 years, +2 years just to be safe
+const yearEnd = currentYear + 7;
+// range of years that can be assigned as a role.
+enum validRoleYears {
+  validRoleYearStart = currentYear - 2,
+  validRoleYearEnd = yearEnd
+};
 
 export enum configMaps {
   aboutme = 'about_me',
@@ -157,7 +167,11 @@ export const getUserProfileById = async (userId: string): Promise<UserProfile | 
 
 // NOTE: data will always be just one customization, but we do not know which one, meaning many of
 // the loops are just to extract an unknown key-val pair
-export const editUserProfileById = async (userId: string, data: UserProfile): Promise<void> => {
+export const editUserProfileById = async (userId: string, data: UserProfile, message: Message): Promise<void> => {
+  // grab oldYear as that might be used later on when updating year roles
+  const oldProfileDetails: UserProfile | undefined = await getUserProfileById(userId);
+  let oldYear = oldProfileDetails?.year || null; 
+
   const db = await openDB();
   // check if a user exists in the user_profile_table already
   const res = await db.get(
@@ -166,9 +180,10 @@ export const editUserProfileById = async (userId: string, data: UserProfile): Pr
   );
   const user = res;
   let query;
+  let onlyCustomization; // declare on outerscope, we need to see if this is the year customization
+  let onlyDescription;
+  
   if (user.found === 1) {
-    let onlyDescription;
-    let onlyCustomization;
     for (const [customization, description] of Object.entries(data)) {
       // grab the only customization and its corresponding description
       onlyCustomization = customization;
@@ -194,4 +209,77 @@ export const editUserProfileById = async (userId: string, data: UserProfile): Pr
     description.replace(/'/g, "''");
     await db.run(query, userId, description);
   }
+  // if database manages to update, and customization is year change year roles roles as well
+  if (onlyCustomization && onlyCustomization === "year"){
+    // onlyDescription here would be the new year role
+    updateProfileRoles(message, oldYear, onlyDescription);
+  }
 };
+
+const addOrRemove = { 
+  add: true,
+  remove: false
+}
+
+const updateRoleByRoleName = async (message: Message, roleName: string, add: boolean): Promise<void> => {
+  const member = message.member;
+  const userId = getUserFromMessage(message).id;
+  const role = await message.guild?.roles.cache.find(role => role?.name === roleName);
+  if (!role) {
+    console.log(`Could not find the role ${roleName}`);
+    return;
+  }
+  try {
+    // log success and failure if need to debug
+    if (add){
+      await member?.roles.add(role);
+      console.log(`Added the year role ${roleName} to user ${userId}`)
+    } else {
+      await member?.roles.remove(role);
+      console.log(`Removed the year role ${roleName} to user ${userId}`)
+    }
+  } catch (err) {
+    console.log(`Failed to ${add ? "add": "remove"} to user ${userId}`);
+  }
+  return;
+}
+
+export const updateProfileRoles = async (message: Message, oldYear:number | null, gradYear: number): Promise<void> => {
+  if (gradYear < currentYear){
+    // assign alumni role to the user 
+    updateRoleByRoleName(message, "Alumni", addOrRemove.add);
+  } else {
+    // remove alumni role to the user if they for some reason have the alumni role and are not graduated
+    updateRoleByRoleName(message, "Alumni", addOrRemove.remove);
+  }
+
+  if (gradYear >= validRoleYears.validRoleYearStart && gradYear <= validRoleYears.validRoleYearEnd){
+    // check if role for that year exists, if not add it
+    const newYearRoleName = gradYear.toString();
+    let findRole = message.guild?.roles.cache.find(role => role?.name === newYearRoleName);
+    
+    if (!findRole){
+      try {
+        // create role object 
+        const newRole = {
+          name: newYearRoleName,
+          color: "GREY" as ColorResolvable,
+          reason: `AUTOMATED: Creating new year role for ${newYearRoleName}`
+        }
+        await message.guild?.roles.create(newRole);
+        findRole = await message.guild?.roles.cache.find(role => role?.name === newYearRoleName)
+        console.log(`CREATED YEAR ROLE FOR ${newYearRoleName}`)
+      } catch (err){
+        console.log(`FAILED TO CREATE YEAR ROLE FOR ${newYearRoleName}: REASON: ${err}`)
+      }
+    }
+    // assign that role to the user
+    updateRoleByRoleName(message, newYearRoleName, addOrRemove.add)
+    // final step: remove their existing year role
+    if (oldYear && newYearRoleName !== oldYear.toString()){
+      updateRoleByRoleName(message, oldYear.toString(), addOrRemove.remove)
+    }
+  }
+
+  return;
+}


### PR DESCRIPTION
## Summary of Changes
<!-- A summary or description of changes made in this PR. -->
- When users use .set profile year, year roles will be automatically assigned/removed.
 
## Motivation and Explanation
<!-- How and why do your changes improve the bot? -->
- Manually creating new roles for each new year is tiring and could be automated. Furthermore, we have an easy way to identify alumni since the profile feature already exists.

## Related Issues
<!-- Issue(s) that this PR will resolve, e.g. "resolves <issue link here>". -->
resolves <https://github.com/uwcsc/codeybot/issues/229>
## Steps to Reproduce
<!-- List the steps needed for the reviewer to produce your PR changes. -->
- Run .profile set <year> 
- Observe if the year is less than the current year, then you will automatically be assigned the alumni role 
- Observe that if the year is within the currentYears range identified by the original ticket known as the enum "validRoleYears" on the pr, then you will get that year assigned as a role to you.
- Observe that if the year is within the currentYears range and the role does not exist, the bot will automatically create this role.

## Demonstration of Changes
<!-- If applicable, include screenshots to illustrate your new feature or fix. -->
BEFORE: 
<img width="336" alt="image" src="https://user-images.githubusercontent.com/36215359/185498226-06daf6d6-e717-486c-bc1e-8e6ba395069f.png">
MESSAGE SENT: 
<img width="374" alt="image" src="https://user-images.githubusercontent.com/36215359/185498257-c4f8dbd1-faa9-4fc4-a93e-e81fcc5834ab.png">
AFTER: 
<img width="305" alt="image" src="https://user-images.githubusercontent.com/36215359/185498279-0f30531d-1219-4af1-a542-781ba8915e2d.png">


## Further Information and Comments

