### PR TITLE
Single player RPS

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,7 +1,4 @@
 {
-  // Use IntelliSense to learn about possible attributes.
-  // Hover to view descriptions of existing attributes.
-  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
   "version": "0.2.0",
   "configurations": [
     {

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,24 @@
+{
+  // Use IntelliSense to learn about possible attributes.
+  // Hover to view descriptions of existing attributes.
+  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "Run Bot Locally",
+      "skipFiles": [
+        "<node_internals>/**"
+      ],
+      "preLaunchTask": "buildBot",
+      "runtimeExecutable": "npm",
+      "runtimeArgs": [
+          "run-script", "local:run"
+      ],
+      "outFiles": [
+        "${workspaceFolder}/dist/**/*.js"
+      ]
+    }
+  ]
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,13 @@
+{
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "type": "npm",
+      "script": "ts:build",
+      "group": "build",
+      "problemMatcher": [],
+      "label": "buildBot",
+      "detail": "tsc"
+    }
+  ]
+}

--- a/src/codeyCommand.ts
+++ b/src/codeyCommand.ts
@@ -318,8 +318,8 @@ export class CodeyCommand extends SapphireCommand {
       if (!successResponse) return;
       // If response contains metadata
       if (successResponse instanceof SapphireMessageResponseWithMetadata) {
-        const response = (<SapphireMessageResponseWithMetadata>successResponse).response;
-        // If response is not void, reply to the original message with the response
+        const response = successResponse.response;
+        // If response is not undefined, reply to the original message with the response
         if (typeof response !== 'undefined') {
           const msg = await message.reply(<string | MessagePayload>response);
           if (commandDetails.afterMessageReply) {
@@ -328,13 +328,13 @@ export class CodeyCommand extends SapphireCommand {
           return msg;
         }
       }
-      // If it does not
+      // If response does not contain metadata
       else {
         return await message.reply(<string | MessagePayload>successResponse);
       }
     } catch (e) {
       logger.error(e);
-      return await message.reply(commandDetails.messageIfFailure ?? defaultBackendErrorMessage);
+      message.reply(commandDetails.messageIfFailure ?? defaultBackendErrorMessage);
     }
   }
 
@@ -395,8 +395,8 @@ export class CodeyCommand extends SapphireCommand {
         successResponse.response = { content: successResponse.response };
       }
 
+      // cannot double reply to a slash command (in case command replies on its own), runtime error
       if (!interaction.replied) {
-        // cannot double reply to a slash command (in case command replies on its own), runtime error
         await interaction.reply(
           Object.assign(
             {

--- a/src/codeyCommand.ts
+++ b/src/codeyCommand.ts
@@ -388,8 +388,15 @@ export class CodeyCommand extends SapphireCommand {
           content: successResponse,
         };
       }
-      // cannot double reply to a slash command (in case command replies on its own), runtime error
+      if (
+        successResponse instanceof SapphireMessageResponseWithMetadata &&
+        typeof successResponse.response === 'string'
+      ) {
+        successResponse.response = { content: successResponse.response };
+      }
+
       if (!interaction.replied) {
+        // cannot double reply to a slash command (in case command replies on its own), runtime error
         await interaction.reply(
           Object.assign(
             {

--- a/src/commandDetails/games/rps.ts
+++ b/src/commandDetails/games/rps.ts
@@ -1,0 +1,41 @@
+import { container } from '@sapphire/framework';
+import {
+  CodeyCommandDetails,
+  CodeyCommandOptionType,
+  getUserFromMessage,
+  SapphireMessageExecuteType,
+} from '../../codeyCommand';
+import { startGame } from '../../components/games/rps';
+
+const rpsExecuteCommand: SapphireMessageExecuteType = async (client, messageFromUser, args) => {
+  const bet = (args['bet'] ?? 10) as number;
+  const game = await startGame(
+    bet,
+    getUserFromMessage(messageFromUser).id,
+    messageFromUser.channelId,
+  );
+  console.log(game);
+  return 'rps';
+};
+
+export const rpsCommandDetails: CodeyCommandDetails = {
+  name: 'rps',
+  aliases: [],
+  description: 'Play Rock, Paper, Scissors!',
+  detailedDescription: `**Examples:**
+\`${container.botPrefix}rps\`
+\`${container.botPrefix}rps 10\``,
+
+  isCommandResponseEphemeral: false,
+  messageWhenExecutingCommand: 'Setting up your RPS game...',
+  executeCommand: rpsExecuteCommand,
+  options: [
+    {
+      name: 'bet',
+      description: 'How much to bet - default is 10',
+      type: CodeyCommandOptionType.INTEGER,
+      required: false,
+    },
+  ],
+  subcommandDetails: {},
+};

--- a/src/commandDetails/games/rps.ts
+++ b/src/commandDetails/games/rps.ts
@@ -1,5 +1,4 @@
 import { container } from '@sapphire/framework';
-import { CommandInteraction } from 'discord.js';
 import {
   CodeyCommandDetails,
   CodeyCommandOptionType,
@@ -7,7 +6,6 @@ import {
   SapphireAfterReplyType,
   SapphireMessageExecuteType,
   SapphireMessageResponseWithMetadata,
-  SapphireSentMessageType,
 } from '../../codeyCommand';
 import { getCoinBalanceByUserId } from '../../components/coin';
 import { getCoinEmoji } from '../../components/emojis';
@@ -29,6 +27,9 @@ const rpsExecuteCommand: SapphireMessageExecuteType = async (
       `You don't have enough ${getCoinEmoji()} to place that bet.`,
       {},
     );
+  }
+  if (bet < 10) {
+    return new SapphireMessageResponseWithMetadata(`Minimum bet is 10 ${getCoinEmoji()}.`, {});
   }
 
   const game = await rpsGameTracker.startGame(

--- a/src/commandDetails/games/rps.ts
+++ b/src/commandDetails/games/rps.ts
@@ -36,7 +36,10 @@ const rpsExecuteCommand: SapphireMessageExecuteType = async (
 };
 
 const rpsAfterMessageReply: SapphireAfterReplyType = async (result, sentMessage) => {
-  
+  // Store the message which the game takes place in the game object
+  rpsGameTracker.runFuncOnGame(<number>result.metadata.gameId, (game) => {
+    game.gameMessage = sentMessage;
+  });
 };
 
 export const rpsCommandDetails: CodeyCommandDetails = {

--- a/src/commandDetails/games/rps.ts
+++ b/src/commandDetails/games/rps.ts
@@ -1,13 +1,11 @@
 import { container } from '@sapphire/framework';
-import { MessageEmbed } from 'discord.js';
 import {
   CodeyCommandDetails,
   CodeyCommandOptionType,
   getUserFromMessage,
   SapphireMessageExecuteType,
 } from '../../codeyCommand';
-import { getCoinEmoji, getEmojiByName } from '../../components/emojis';
-import { RpsGameSign, RpsGameStatus, startGame } from '../../components/games/rps';
+import { rpsGameTracker } from '../../components/games/rps';
 
 const rpsExecuteCommand: SapphireMessageExecuteType = async (_client, messageFromUser, args) => {
   /* 
@@ -15,7 +13,8 @@ const rpsExecuteCommand: SapphireMessageExecuteType = async (_client, messageFro
     the subsequent interactionHandlers handle the rest of the logic
   */
   const bet = (args['bet'] ?? 10) as number;
-  const game = await startGame(
+
+  const game = await rpsGameTracker.startGame(
     bet,
     messageFromUser.channelId,
     getUserFromMessage(messageFromUser),

--- a/src/commandDetails/games/rps.ts
+++ b/src/commandDetails/games/rps.ts
@@ -5,7 +5,7 @@ import {
   getUserFromMessage,
   SapphireMessageExecuteType,
 } from '../../codeyCommand';
-import { startGame } from '../../components/games/rps';
+import { RpsGameSign, startGame } from '../../components/games/rps';
 
 const rpsExecuteCommand: SapphireMessageExecuteType = async (client, messageFromUser, args) => {
   const bet = (args['bet'] ?? 10) as number;
@@ -14,7 +14,7 @@ const rpsExecuteCommand: SapphireMessageExecuteType = async (client, messageFrom
     getUserFromMessage(messageFromUser).id,
     messageFromUser.channelId,
   );
-  console.log(game);
+  game.runGame(RpsGameSign.Rock, RpsGameSign.Scissors);
   return 'rps';
 };
 

--- a/src/commandDetails/games/rps.ts
+++ b/src/commandDetails/games/rps.ts
@@ -1,21 +1,29 @@
 import { container } from '@sapphire/framework';
+import { MessageEmbed } from 'discord.js';
 import {
   CodeyCommandDetails,
   CodeyCommandOptionType,
   getUserFromMessage,
   SapphireMessageExecuteType,
 } from '../../codeyCommand';
-import { RpsGameSign, startGame } from '../../components/games/rps';
+import { getCoinEmoji, getEmojiByName } from '../../components/emojis';
+import { RpsGameSign, RpsGameStatus, startGame } from '../../components/games/rps';
 
-const rpsExecuteCommand: SapphireMessageExecuteType = async (client, messageFromUser, args) => {
+const rpsExecuteCommand: SapphireMessageExecuteType = async (_client, messageFromUser, args) => {
+  /* 
+    executeCommand sends the initial RPS embed; 
+    the subsequent interactionHandlers handle the rest of the logic
+  */
   const bet = (args['bet'] ?? 10) as number;
   const game = await startGame(
     bet,
-    getUserFromMessage(messageFromUser).id,
     messageFromUser.channelId,
+    getUserFromMessage(messageFromUser),
+    undefined, // We should change this when we implement 2 players
   );
-  game.runGame(RpsGameSign.Rock, RpsGameSign.Scissors);
-  return 'rps';
+
+  // Return initial response
+  return game.getGameResponse();
 };
 
 export const rpsCommandDetails: CodeyCommandDetails = {

--- a/src/commandDetails/games/rps.ts
+++ b/src/commandDetails/games/rps.ts
@@ -1,13 +1,21 @@
 import { container } from '@sapphire/framework';
+import { CommandInteraction } from 'discord.js';
 import {
   CodeyCommandDetails,
   CodeyCommandOptionType,
   getUserFromMessage,
+  SapphireAfterReplyType,
   SapphireMessageExecuteType,
+  SapphireMessageResponseWithMetadata,
+  SapphireSentMessageType,
 } from '../../codeyCommand';
 import { rpsGameTracker } from '../../components/games/rps';
 
-const rpsExecuteCommand: SapphireMessageExecuteType = async (_client, messageFromUser, args) => {
+const rpsExecuteCommand: SapphireMessageExecuteType = async (
+  _client,
+  messageFromUser,
+  args,
+): Promise<SapphireMessageResponseWithMetadata> => {
   /* 
     executeCommand sends the initial RPS embed; 
     the subsequent interactionHandlers handle the rest of the logic
@@ -22,7 +30,13 @@ const rpsExecuteCommand: SapphireMessageExecuteType = async (_client, messageFro
   );
 
   // Return initial response
-  return game.getGameResponse();
+  return new SapphireMessageResponseWithMetadata(game.getGameResponse(), {
+    gameId: game.id,
+  });
+};
+
+const rpsAfterMessageReply: SapphireAfterReplyType = async (result, sentMessage) => {
+  
 };
 
 export const rpsCommandDetails: CodeyCommandDetails = {
@@ -36,6 +50,7 @@ export const rpsCommandDetails: CodeyCommandDetails = {
   isCommandResponseEphemeral: false,
   messageWhenExecutingCommand: 'Setting up your RPS game...',
   executeCommand: rpsExecuteCommand,
+  afterMessageReply: rpsAfterMessageReply,
   options: [
     {
       name: 'bet',

--- a/src/commands/games/rps.ts
+++ b/src/commands/games/rps.ts
@@ -1,0 +1,16 @@
+import { Command } from '@sapphire/framework';
+import { CodeyCommand } from '../../codeyCommand';
+import { rpsCommandDetails } from '../../commandDetails/games/rps';
+
+export class RpsCommand extends CodeyCommand {
+  details = rpsCommandDetails;
+
+  public constructor(context: Command.Context, options: Command.Options) {
+    super(context, {
+      ...options,
+      aliases: rpsCommandDetails.aliases,
+      description: rpsCommandDetails.description,
+      detailedDescription: rpsCommandDetails.detailedDescription,
+    });
+  }
+}

--- a/src/commands/games/rps.ts
+++ b/src/commands/games/rps.ts
@@ -2,7 +2,7 @@ import { Command } from '@sapphire/framework';
 import { CodeyCommand } from '../../codeyCommand';
 import { rpsCommandDetails } from '../../commandDetails/games/rps';
 
-export class RpsCommand extends CodeyCommand {
+export class GamesRpsCommand extends CodeyCommand {
   details = rpsCommandDetails;
 
   public constructor(context: Command.Context, options: Command.Options) {

--- a/src/components/coin.ts
+++ b/src/components/coin.ts
@@ -14,6 +14,9 @@ export enum UserCoinEvent {
   BonusActivity,
   BonusInterviewerList,
   Blackjack,
+  RpsLoss,
+  RpsDrawAgainstCodey,
+  RpsWin,
 }
 
 export type Bonus = {

--- a/src/components/db.ts
+++ b/src/components/db.ts
@@ -121,6 +121,7 @@ const initUserProfileTable = async (db: Database): Promise<void> => {
 };
 
 const initRpsGameInfo = async (db: Database): Promise<void> => {
+  // If player 2 ID is null, the game was against Codey
   await db.run(
     `
       CREATE TABLE IF NOT EXISTS rps_game_info (

--- a/src/components/db.ts
+++ b/src/components/db.ts
@@ -120,6 +120,23 @@ const initUserProfileTable = async (db: Database): Promise<void> => {
   );
 };
 
+const initRpsGameInfo = async (db: Database): Promise<void> => {
+  await db.run(
+    `
+      CREATE TABLE IF NOT EXISTS rps_game_info (
+        id INTEGER PRIMARY KEY NOT NULL,
+        created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+        player1_id VARCHAR(30) NOT NULL,
+        player2_id VARCHAR(30),
+        bet INTEGER NOT NULL,
+        player1_sign INTEGER NOT NULL DEFAULT 0,
+        player2_sign INTEGER NOT NULL DEFAULT 0,
+        status INTEGER NOT NULL DEFAULT 0
+      )
+    `,
+  );
+};
+
 const initTables = async (db: Database): Promise<void> => {
   //initialize all relevant tables
   await initCoffeeChatTables(db);
@@ -129,6 +146,7 @@ const initTables = async (db: Database): Promise<void> => {
   await initUserCoinLedgerTable(db);
   await initUserCoinTable(db);
   await initUserProfileTable(db);
+  await initRpsGameInfo(db);
 };
 
 export const openDB = async (): Promise<Database> => {

--- a/src/components/games/rps.ts
+++ b/src/components/games/rps.ts
@@ -1,0 +1,73 @@
+import { openDB } from '../db';
+import { logger } from '../../logger/default';
+
+export class RpsGame {
+  id: number;
+  channelId: string;
+  state: RpsGameState;
+
+  constructor(id: number, channelId: string, state: RpsGameState) {
+    this.id = id;
+    this.channelId = channelId;
+    this.state = state;
+  }
+}
+
+export enum RpsGameStatus {
+  Pending = 0,
+  Player1Win = 1,
+  Draw = 2,
+  Player2Win = 3,
+  Player1TimeOut = 4,
+  Player2TimeOut = 5,
+}
+
+export enum RpsGameSign {
+  Pending = 0,
+  Rock = 1,
+  Paper = 2,
+  Scissors = 3,
+}
+
+export type RpsGameState = {
+  player1Id: string;
+  player2Id?: string;
+  bet: number;
+  status: RpsGameStatus;
+  player1Sign: RpsGameSign;
+  player2Sign: RpsGameSign;
+};
+
+/*
+  Starts a RPS game
+*/
+export const startGame = async (
+  bet: number,
+  channelId: string,
+  player1Id: string,
+  player2Id?: string,
+): Promise<RpsGame> => {
+  const db = await openDB();
+  const result = await db.run(
+    `
+    INSERT INTO rps_game_info (player1_id, player2_id, bet)
+    VALUES (?, ?, ?)
+  `,
+    [player1Id, player2Id, bet],
+  );
+  // get last inserted ID
+  const id = result.lastID;
+  if (!id) {
+    const state: RpsGameState = {
+      player1Id,
+      player2Id,
+      bet,
+      status: 0,
+      player1Sign: 0,
+      player2Sign: 0,
+    };
+    const game = new RpsGame(id!, channelId, state);
+    return game;
+  }
+  throw new Error('Something went wrong when starting the RPS game');
+};

--- a/src/components/games/rps.ts
+++ b/src/components/games/rps.ts
@@ -113,7 +113,7 @@ class RpsGameTracker {
       SET player1_sign = ?, player2_sign = ?, status = ?
       WHERE id=?
       `,
-      [game?.state.player1Sign, game?.state.player2Sign, game?.state.status],
+      [game?.state.player1Sign, game?.state.player2Sign, game?.state.status, game?.id],
     );
     rpsGameTracker.games.delete(gameId);
   }

--- a/src/components/games/rps.ts
+++ b/src/components/games/rps.ts
@@ -323,7 +323,11 @@ export type RpsGameState = {
   player2Sign: RpsGameSign;
 };
 
+function getRandomInt(max: number) {
+  return Math.floor(Math.random() * max);
+}
+
 // Algorithm to get RPS game sign for Codey
 export const getCodeyRpsSign = (): RpsGameSign => {
-  return RpsGameSign.Rock;
+  return 1 + getRandomInt(3);
 };

--- a/src/components/games/rps.ts
+++ b/src/components/games/rps.ts
@@ -146,15 +146,15 @@ ${this.state.player2Username} picked: ${getEmojiFromSign(this.state.player2Sign)
     // Buttons
     const row = new MessageActionRow().addComponents(
       new MessageButton()
-        .setCustomId(`rock-${this.id}`)
+        .setCustomId(`rps-rock-${this.id}`)
         .setLabel(getEmojiFromSign(RpsGameSign.Rock))
         .setStyle('SECONDARY'),
       new MessageButton()
-        .setCustomId(`paper-${this.id}`)
+        .setCustomId(`rps-paper-${this.id}`)
         .setLabel(getEmojiFromSign(RpsGameSign.Paper))
         .setStyle('SECONDARY'),
       new MessageButton()
-        .setCustomId(`scissors-${this.id}`)
+        .setCustomId(`rps-scissors-${this.id}`)
         .setLabel(getEmojiFromSign(RpsGameSign.Scissors))
         .setStyle('SECONDARY'),
     );

--- a/src/components/games/rps.ts
+++ b/src/components/games/rps.ts
@@ -16,6 +16,10 @@ class RpsGameTracker {
     return this.games.get(id);
   }
 
+  runFuncOnGame(gameId: number, func: (game: RpsGame) => void): void {
+    func(this.getGameFromId(gameId)!);
+  }
+
   /*
     Starts a RPS game
   */

--- a/src/components/games/rps.ts
+++ b/src/components/games/rps.ts
@@ -2,7 +2,7 @@ import { openDB } from '../db';
 import { logger } from '../../logger/default';
 import { MessageActionRow, MessageButton, MessageEmbed, MessagePayload, User } from 'discord.js';
 import { getCoinEmoji, getEmojiByName } from '../emojis';
-import { SapphireMessageResponse } from '../../codeyCommand';
+import { SapphireMessageResponse, SapphireSentMessageType } from '../../codeyCommand';
 
 class RpsGameTracker {
   // Key = id, Value = game
@@ -59,6 +59,7 @@ export const rpsGameTracker = new RpsGameTracker();
 export class RpsGame {
   id: number;
   channelId: string;
+  gameMessage!: SapphireSentMessageType;
   state: RpsGameState;
 
   constructor(id: number, channelId: string, state: RpsGameState) {

--- a/src/components/games/rps.ts
+++ b/src/components/games/rps.ts
@@ -115,6 +115,7 @@ class RpsGameTracker {
       `,
       [game?.state.player1Sign, game?.state.player2Sign, game?.state.status],
     );
+    rpsGameTracker.games.delete(gameId);
   }
 }
 

--- a/src/components/games/rps.ts
+++ b/src/components/games/rps.ts
@@ -57,7 +57,7 @@ export const startGame = async (
   );
   // get last inserted ID
   const id = result.lastID;
-  if (!id) {
+  if (id) {
     const state: RpsGameState = {
       player1Id,
       player2Id,

--- a/src/components/games/rps.ts
+++ b/src/components/games/rps.ts
@@ -1,6 +1,6 @@
 import { openDB } from '../db';
 import { logger } from '../../logger/default';
-import { MessageActionRow, MessageButton, MessageEmbed, MessagePayload, User } from 'discord.js';
+import { ColorResolvable, MessageActionRow, MessageButton, MessageEmbed, MessagePayload, User } from 'discord.js';
 import { getCoinEmoji, getEmojiByName } from '../emojis';
 import { SapphireMessageResponse, SapphireSentMessageType } from '../../codeyCommand';
 
@@ -122,10 +122,23 @@ export class RpsGame {
     }
   }
 
+  public getEmbedColor(): ColorResolvable {
+    switch (this.state.status) {
+      case RpsGameStatus.Player1Win:
+        return 'GREEN';
+      case RpsGameStatus.Player2Win:
+        return this.state.player2Id ? 'GREEN' : 'RED';
+      case RpsGameStatus.Draw:
+        return 'ORANGE';
+      default:
+        return 'YELLOW';
+    }
+  }
+
   // Prints embed and buttons for the game
   public getGameResponse(): SapphireMessageResponse {
     const embed = new MessageEmbed()
-      .setColor('YELLOW')
+      .setColor(this.getEmbedColor())
       .setTitle('Rock, Paper, Scissors!')
       .setDescription(
         `
@@ -188,7 +201,7 @@ export enum RpsGameSign {
   Scissors = 3,
 }
 
-const getEmojiFromSign = (sign: RpsGameSign): string => {
+export const getEmojiFromSign = (sign: RpsGameSign): string => {
   switch (sign) {
     case RpsGameSign.Pending:
       return '❓';
@@ -211,3 +224,8 @@ export type RpsGameState = {
   player1Sign: RpsGameSign;
   player2Sign: RpsGameSign;
 };
+
+// Algorithm to get RPS game sign for Codey
+export const getCodeyRpsSign = (): RpsGameSign => {
+  return RpsGameSign.Rock;
+}

--- a/src/components/games/rps.ts
+++ b/src/components/games/rps.ts
@@ -11,6 +11,67 @@ export class RpsGame {
     this.channelId = channelId;
     this.state = state;
   }
+
+  private determineWinner(
+    player1Sign: RpsGameSign,
+    player2Sign: RpsGameSign,
+  ): 'player1' | 'player2' | 'tie' {
+    if (player1Sign === player2Sign) {
+      return 'tie';
+    }
+    if (
+      (player1Sign === RpsGameSign.Paper && player2Sign === RpsGameSign.Rock) ||
+      (player1Sign === RpsGameSign.Scissors && player2Sign === RpsGameSign.Paper) ||
+      (player1Sign === RpsGameSign.Rock && player2Sign === RpsGameSign.Scissors)
+    ) {
+      return 'player1';
+    }
+    return 'player2';
+  }
+
+  private getStatus(timeout: 'player1' | 'player2' | null): RpsGameStatus {
+    // Both players submitted a sign
+    if (timeout === null) {
+      /*
+        If one of the players' signs is still pending, something went wrong
+      */
+      if (
+        this.state.player1Sign === RpsGameSign.Pending ||
+        this.state.player2Sign === RpsGameSign.Pending
+      ) {
+        return RpsGameStatus.Unknown;
+      } else {
+        const winner = this.determineWinner(this.state.player1Sign, this.state.player2Sign);
+        switch (winner) {
+          case 'player1':
+            return RpsGameStatus.Player1Win;
+          case 'player2':
+            return RpsGameStatus.Player2Win;
+          case 'tie':
+            return RpsGameStatus.Draw;
+          default:
+            return RpsGameStatus.Unknown;
+        }
+      }
+    } else if (timeout === 'player1') {
+      return RpsGameStatus.Player1TimeOut;
+    } else if (timeout === 'player2') {
+      return RpsGameStatus.Player2TimeOut;
+    } else {
+      return RpsGameStatus.Unknown;
+    }
+  }
+
+  runGame(player1Sign: RpsGameSign, player2Sign: RpsGameSign) {
+    /*
+      Time out can be implemented later on or in a later issue
+    */
+    const timeout = null;
+
+    this.state.player1Sign = player1Sign;
+    this.state.player2Sign = player2Sign;
+    this.state.status = this.getStatus(timeout);
+  }
 }
 
 export enum RpsGameStatus {
@@ -20,6 +81,7 @@ export enum RpsGameStatus {
   Player2Win = 3,
   Player1TimeOut = 4,
   Player2TimeOut = 5,
+  Unknown = 6,
 }
 
 export enum RpsGameSign {

--- a/src/interaction-handlers/games/rps.ts
+++ b/src/interaction-handlers/games/rps.ts
@@ -61,7 +61,6 @@ export class RpsHandler extends InteractionHandler {
         game.gameMessage.editReply(<MessagePayload>game.getGameResponse());
       }
     });
-    // If game has ended, call endGame
     rpsGameTracker.endGame(result.gameId);
     // We need to do this to avoid "failed interaction" after selecting our option
     await interaction.reply({

--- a/src/interaction-handlers/games/rps.ts
+++ b/src/interaction-handlers/games/rps.ts
@@ -1,7 +1,8 @@
 import { InteractionHandler, InteractionHandlerTypes, PieceContext } from '@sapphire/framework';
 import type { ButtonInteraction } from 'discord.js';
+import { RpsGame, RpsGameSign, rpsGameTracker } from '../../components/games/rps';
 
-export class ButtonHandler extends InteractionHandler {
+export class RpsHandler extends InteractionHandler {
   public constructor(ctx: PieceContext, options: InteractionHandler.Options) {
     super(ctx, {
       ...options,
@@ -10,13 +11,36 @@ export class ButtonHandler extends InteractionHandler {
   }
 
   // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
+  // Get the game info and the interaction type
   public override parse(interaction: ButtonInteraction) {
-    if (interaction.customId !== 'my-awesome-button') return this.none();
-    return this.some();
+    if (!interaction.customId.startsWith('rps')) return this.none();
+    const parsedCustomId = interaction.customId.split('_');
+    const sign = parsedCustomId[1];
+    const gameId = <number>(<unknown>parsedCustomId[2]);
+
+    let gameSign: RpsGameSign;
+    switch (sign) {
+      case 'rock':
+        gameSign = RpsGameSign.Rock;
+        break;
+      case 'paper':
+        gameSign = RpsGameSign.Paper;
+        break;
+      case 'scissors':
+        gameSign = RpsGameSign.Scissors;
+        break;
+      default:
+        gameSign = RpsGameSign.Pending;
+        break;
+    }
+    return this.some({
+      game: rpsGameTracker.getGameFromId(gameId),
+      sign: gameSign,
+    });
   }
 
   // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
-  public async run(interaction: ButtonInteraction) {
+  public async run(interaction: ButtonInteraction, result: { game: RpsGame; sign: RpsGameSign }) {
     await interaction.reply({
       content: 'Hello from a button interaction handler!',
       // Let's make it so only the person who pressed the button can see this message!

--- a/src/interaction-handlers/games/rps.ts
+++ b/src/interaction-handlers/games/rps.ts
@@ -1,0 +1,26 @@
+import { InteractionHandler, InteractionHandlerTypes, PieceContext } from '@sapphire/framework';
+import type { ButtonInteraction } from 'discord.js';
+
+export class ButtonHandler extends InteractionHandler {
+  public constructor(ctx: PieceContext, options: InteractionHandler.Options) {
+    super(ctx, {
+      ...options,
+      interactionHandlerType: InteractionHandlerTypes.Button,
+    });
+  }
+
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
+  public override parse(interaction: ButtonInteraction) {
+    if (interaction.customId !== 'my-awesome-button') return this.none();
+    return this.some();
+  }
+
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
+  public async run(interaction: ButtonInteraction) {
+    await interaction.reply({
+      content: 'Hello from a button interaction handler!',
+      // Let's make it so only the person who pressed the button can see this message!
+      ephemeral: true,
+    });
+  }
+}

--- a/src/interaction-handlers/games/rps.ts
+++ b/src/interaction-handlers/games/rps.ts
@@ -5,6 +5,7 @@ import {
   getEmojiFromSign,
   RpsGame,
   RpsGameSign,
+  RpsGameStatus,
   rpsGameTracker,
 } from '../../components/games/rps';
 

--- a/src/interaction-handlers/games/rps.ts
+++ b/src/interaction-handlers/games/rps.ts
@@ -53,7 +53,7 @@ export class RpsHandler extends InteractionHandler {
       // If single player, get Codey's sign
       if (!game.state.player2Id) {
         game.state.player2Sign = getCodeyRpsSign();
-        game.state.status = game.getStatus(null);
+        game.setStatus(null);
       }
       if (game.gameMessage instanceof Message) {
         game.gameMessage.edit(<MessagePayload>game.getGameResponse());
@@ -61,6 +61,8 @@ export class RpsHandler extends InteractionHandler {
         game.gameMessage.editReply(<MessagePayload>game.getGameResponse());
       }
     });
+    // If game has ended, call endGame
+    rpsGameTracker.endGame(result.gameId);
     // We need to do this to avoid "failed interaction" after selecting our option
     await interaction.reply({
       content: `You selected ${getEmojiFromSign(result.sign)}.`,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,8 @@
     "preserveConstEnums": true,
     "esModuleInterop": true,
     "resolveJsonModule": true,
-    "experimentalDecorators": true
+    "experimentalDecorators": true,
+    "sourceMap": true,
   },
   "include": ["**/*.ts"],
   "exclude": ["src/oldCode"]


### PR DESCRIPTION
## Summary of Changes
- Added single player RPS
- Added parameter in `tsconfig.json` that allows TS debugging on VSCode

For single player, to make it "fair", Codey takes half of your bet if you draw.

## Motivation and Explanation
We need to kickstart the games epic, and have more games apart from just Blackjack. Moreover, the changes/logic here can be generalized for other games.

## Related Issues
Resolves #339 (single player)

## Steps to Reproduce
`.rps [bet]` or `/rps [bet]`

In VSCode, if you type `F5`, the debugger should also run.

## Demonstration of Changes
![image](https://user-images.githubusercontent.com/76544623/187039446-3b91c31a-b408-4368-944f-6611bd44c675.png)

Initial game screen
![image](https://user-images.githubusercontent.com/76544623/187039455-424b1c02-9a75-4ea5-802d-d8a1a736cd86.png)

After clicking the rock emoji (Codey selected Rock):
![image](https://user-images.githubusercontent.com/76544623/187039479-6659e6ac-bd76-447c-be3a-bd643de15c7a.png)

Similar screens exist for winning and losing.

## Further Information and Comments
- Timeouts are not implemented - this should be for another issue
- This uses `interaction-handlers`, which are Sapphire-specific, so desapphirication would also need to fix those.

