### PR TITLE
Change default board issues are moved to project board

### DIFF
--- a/.github/workflows/addCreatedIssueToBacklog.yml
+++ b/.github/workflows/addCreatedIssueToBacklog.yml
@@ -12,5 +12,5 @@ jobs:
     steps:
       - uses: actions/add-to-project@v0.3.0
         with:
-          project-url: https://github.com/orgs/uwcsc/projects/3
+          project-url: https://github.com/orgs/uwcsc/projects/2
           github-token: ${{ secrets.ADD_TO_PROJECT_PAT }}

--- a/.github/workflows/addCreatedIssueToProjectBoard.yml
+++ b/.github/workflows/addCreatedIssueToProjectBoard.yml
@@ -1,4 +1,4 @@
-name: Add created issue to backlog
+name: Add created issue to Project Board
 
 on:
   issues:


### PR DESCRIPTION
## Summary of Changes

Changed the default board issues are moved to to the "project board".

## Motivation and Explanation

We are planning to use one project board instead of the two that are currently in place (Backlog and Active). So, we want to change the default board issues are added to in the GH action to this new "centralized" project board.

## Related Issues
Resolves #376 

