### PR TITLE
Update profile picture image options to enlarge image

### DIFF
--- a/src/commands/profile/profile.ts
+++ b/src/commands/profile/profile.ts
@@ -45,7 +45,7 @@ export class ProfileCommand extends SubCommandPluginCommand {
           user.displayAvatarURL({
             dynamic: true,
             format: 'png',
-            size: 4096
+            size: 4096,
           }),
         );
       }

--- a/src/commands/profile/profile.ts
+++ b/src/commands/profile/profile.ts
@@ -41,7 +41,13 @@ export class ProfileCommand extends SubCommandPluginCommand {
       // setting profile colour might not be useful, but we should leave it to a separate discussion/ticket
       profileDisplay.setColor(DEFAULT_EMBED_COLOUR);
       if (user.avatar) {
-        profileDisplay.setImage(user.displayAvatarURL());
+        profileDisplay.setImage(
+          user.displayAvatarURL({
+            dynamic: true,
+            format: 'png',
+            size: 4096
+          }),
+        );
       }
       for (const [key, val] of Object.entries(profileDetails)) {
         if (val && !notDisplay.includes(key)) {


### PR DESCRIPTION
## Summary of Changes
Profile picture image options changed, now includes the following options:
- dynamic (auto changes to gif for animated avatars)
- format: png
- size: 4096 

## Motivation and Explanation
Profile pictures in user profile have better quality

## Related Issues
Resolves #381 

## Steps to Reproduce
src → commands → profile.ts → about function 

## Demonstration of Changes

## Further Information and Comments

****