### PR TITLE
Fix word pluralization

### DIFF
--- a/src/commandDetails/coin/adjust.ts
+++ b/src/commandDetails/coin/adjust.ts
@@ -12,6 +12,7 @@ import {
   UserCoinEvent,
 } from '../../components/coin';
 import { getCoinEmoji } from '../../components/emojis';
+import { pluralize } from '../../utils/pluralize';
 
 // Adjust coin balance
 const coinAdjustExecuteCommand: SapphireMessageExecuteType = async (
@@ -50,7 +51,8 @@ const coinAdjustExecuteCommand: SapphireMessageExecuteType = async (
   const newBalance = await getCoinBalanceByUserId(user.id);
 
   const COIN = getCoinEmoji();
-  return `Adjusted ${user.username}'s balance by ${amount} ${COIN}.\n${user.username} now has ${newBalance} Codey coins ${COIN}.`;
+  return `Adjusted ${user.username}'s balance by ${amount} ${COIN}.\n
+  ${user.username} now has ${newBalance} Codey ${pluralize('coin', newBalance)} ${COIN}.`;
 };
 
 export const coinAdjustCommandDetails: CodeyCommandDetails = {

--- a/src/commandDetails/coin/check.ts
+++ b/src/commandDetails/coin/check.ts
@@ -9,6 +9,7 @@ import {
 } from '../../codeyCommand';
 import { getCoinBalanceByUserId } from '../../components/coin';
 import { getCoinEmoji } from '../../components/emojis';
+import { pluralize } from '../../utils/pluralize';
 
 // Check a user's balance
 const coinCheckExecuteCommand: SapphireMessageExecuteType = async (
@@ -36,7 +37,7 @@ const coinCheckExecuteCommand: SapphireMessageExecuteType = async (
   }
 
   // Show coin balance
-  return `${displayMessage} ${balance} Codey coins ${getCoinEmoji()}.`;
+  return `${displayMessage} ${balance} Codey ${pluralize('coin', balance)} ${getCoinEmoji()}.`;
 };
 
 export const coinCheckCommandDetails: CodeyCommandDetails = {

--- a/src/commandDetails/coin/update.ts
+++ b/src/commandDetails/coin/update.ts
@@ -11,6 +11,7 @@ import {
   UserCoinEvent,
 } from '../../components/coin';
 import { getCoinEmoji } from '../../components/emojis';
+import { pluralize } from '../../utils/pluralize';
 
 // Update coin balance of a user
 const coinUpdateExecuteCommand: SapphireMessageExecuteType = async (
@@ -48,7 +49,10 @@ const coinUpdateExecuteCommand: SapphireMessageExecuteType = async (
   // Get new balance
   const newBalance = await getCoinBalanceByUserId(user.id);
 
-  return `${user.username} now has ${newBalance} Codey coins ${getCoinEmoji()}.`;
+  return `${user.username} now has ${newBalance} Codey ${pluralize(
+    'coin',
+    newBalance,
+  )} ${getCoinEmoji()}.`;
 };
 
 export const coinUpdateCommandDetails: CodeyCommandDetails = {

--- a/src/commands/games/blackjack.ts
+++ b/src/commands/games/blackjack.ts
@@ -25,6 +25,7 @@ import {
   performGameAction,
   startGame,
 } from '../../components/games/blackjack';
+import { pluralize } from '../../utils/pluralize';
 
 const DEFAULT_BET = 10;
 const MIN_BET = 10;
@@ -159,24 +160,25 @@ export class GamesBlackjackCommand extends Command {
     if (game.stage === BlackjackStage.DONE) {
       if (game.surrendered) {
         // player surrendered
-        return `You surrendered and lost **${amountDiff}** Codey coin(s) ${getEmojiByName(
-          'codeySad',
-        )}.`;
+        return `You surrendered and lost **${amountDiff}** Codey ${pluralize(
+          'coin',
+          amountDiff,
+        )} ${getEmojiByName('codeySad')}.`;
       }
       if (game.amountWon < game.bet) {
         // player lost
-        return `You lost **${amountDiff}** Codey coin(s) ${getEmojiByName(
+        return `You lost **${amountDiff}** Codey ${pluralize('coin', amountDiff)} ${getEmojiByName(
           'codeySad',
         )}, better luck next time!`;
       }
       if (game.amountWon > game.bet) {
         // player won
-        return `You won **${amountDiff}** Codey coin(s) ${getEmojiByName(
+        return `You won **${amountDiff}** Codey ${pluralize('coin', amountDiff)} ${getEmojiByName(
           'codeyLove',
         )}, keep your win streak going!`;
       }
       // player tied with dealer
-      return `Tied! You didn't win nor lose any Codey coin(s), try again!`;
+      return `Tied! You didn't win nor lose any Codey ${pluralize('coin', amountDiff)}, try again!`;
     }
     // game instruction
     return 'Press 🇭 to hit, 🇸 to stand, or 🇶 to quit.';

--- a/src/utils/pluralize.ts
+++ b/src/utils/pluralize.ts
@@ -1,0 +1,15 @@
+/**
+ * Returns the plural form of a word. Note this only works for adding an s for now,
+ * in the future we may need to detect different types in this function
+ * e.g: goose -> geese
+ *
+ * @param singularWord - The word in singular form
+ * @param count - The count that the word is referring to
+ * @returns Either the singular or plural form, dependent on the count
+ */
+export const pluralize = (singularWord: string, count: number): string => {
+  if (count > 1) {
+    return singularWord + 's';
+  }
+  return singularWord;
+};

--- a/src/utils/pluralize.ts
+++ b/src/utils/pluralize.ts
@@ -8,7 +8,7 @@
  * @returns Either the singular or plural form, dependent on the count
  */
 export const pluralize = (singularWord: string, count: number): string => {
-  if (count > 1) {
+  if (count > 1 || count == 0) {
     return singularWord + 's';
   }
   return singularWord;


### PR DESCRIPTION
## Summary of Changes
<!-- A summary or description of changes made in this PR. -->
Fixed pluralization of codey coin. If the user has more than 1 or 0 codey coins, the pluralization will add an s.
## Motivation and Explanation
<!-- How and why do your changes improve the bot? -->
Better grammar :)
## Related Issues
<!-- Issue(s) that this PR will resolve, e.g. "resolves <issue link here>". -->
Resolves <https://github.com/uwcsc/codeybot/issues/299>
## Steps to Reproduce
<!-- List the steps needed for the reviewer to produce your PR changes. -->
Any references to codey coins that rely on an amount (e.g: user updated their balance, user wins in the games that award coins) will dynamically set the pluralization.

## Demonstration of Changes
<!-- If applicable, include screenshots to illustrate your new feature or fix. -->
<img width="360" alt="image" src="https://user-images.githubusercontent.com/36215359/192115641-a3777816-0303-4514-9f40-03bd7351ae0f.png">
<img width="348" alt="image" src="https://user-images.githubusercontent.com/36215359/192115653-0f9fc00a-accd-427f-a4c0-6f198a55fcc7.png">
<img width="369" alt="image" src="https://user-images.githubusercontent.com/36215359/192115661-73a4e9c0-3555-4835-b93b-3ad854fbb8f8.png">

## Further Information and Comments

Pluralize helper only works for codey coins right now, and should work with anything that just adds an s for pluralization. Will not work for something like mouse -> mice. This note is also on the docstring