### PR TITLE
389 split instances

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,7 +2,7 @@ name: Build
 
 on:
   push:
-    branches: [main]
+    branches: [main, 389-split-instances]
   pull_request:
     branches: [main]
   release:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,7 +2,7 @@ name: Build
 
 on:
   push:
-    branches: [main, push]
+    branches: [main, 389-split-instances]
   pull_request:
     branches: [main]
   release:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -59,7 +59,7 @@ jobs:
         if: ${{ github.event_name == 'push' }}
         run: |
           echo "DEPLOYMENT_TARGET=staging" >> $GITHUB_ENV
-          echo "DEPLOYMENT_HOST=${{secrets.STAGING_DEPLOY_HOST}}" >> $GITHUB_ENV
+          echo "DEPLOYMENT_HOST=${{secrets.DEPLOY_HOST}}" >> $GITHUB_ENV
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
@@ -96,3 +96,4 @@ jobs:
             echo "TAG=${{ github.event_name == 'push' && github.sha || env.RELEASE_TAG }}" > docker.env
             docker-compose down
             docker-compose --env-file docker.env up -d
+            echo "${{secrets.DEPLOY_HOST}} ${{secrets.DEPLOY_USER}}"" > staging_env.txt

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -52,11 +52,14 @@ jobs:
         run: |
           echo "DEPLOYMENT_TARGET=production" >> $GITHUB_ENV
           echo "RELEASE_TAG=${GITHUB_REF/refs\/tags\//}" >> $GITHUB_ENV
+          echo "DEPLOYMENT_HOST=${{secrets.DEPLOY_HOST}}" >> $GITHUB_ENV
 
       # set target deployment to staging on push
       - name: Configuration for pushes
         if: ${{ github.event_name == 'push' }}
-        run: echo "DEPLOYMENT_TARGET=staging" >> $GITHUB_ENV
+        run: |
+          echo "DEPLOYMENT_TARGET=staging" >> $GITHUB_ENV
+          echo "DEPLOYMENT_HOST=${{secrets.STAGING_DEPLOY_HOST}}" >> $GITHUB_ENV
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
@@ -83,7 +86,7 @@ jobs:
       - name: Pull image and start container in deploy host
         uses: appleboy/ssh-action@master
         with:
-          host: ${{ secrets.DEPLOY_HOST }}
+          host: ${{ env.DEPLOYMENT_HOST }}
           username: ${{ secrets.DEPLOY_USER }}
           key: ${{ secrets.DEPLOY_SSH_KEY }}
           script: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,7 +2,7 @@ name: Build
 
 on:
   push:
-    branches: [main, 389-split-instances]
+    branches: [main]
   pull_request:
     branches: [main]
   release:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,7 +2,7 @@ name: Build
 
 on:
   push:
-    branches: [main]
+    branches: [main, push]
   pull_request:
     branches: [main]
   release:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -88,7 +88,7 @@ jobs:
         with:
           host: ${{ env.DEPLOYMENT_HOST }}
           username: ${{ secrets.DEPLOY_USER }}
-          key: ${{ secrets.DEPLOY_KEY }}
+          key: ${{ secrets.DEPLOY_SSH_KEY }}
           script: |
             cd /codey/${{env.DEPLOYMENT_TARGET}}
             curl -o docker-compose.yml https://raw.githubusercontent.com/uwcsc/codeybot/main/docker/${{env.DEPLOYMENT_TARGET}}/docker-compose.yml

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -59,7 +59,7 @@ jobs:
         if: ${{ github.event_name == 'push' }}
         run: |
           echo "DEPLOYMENT_TARGET=staging" >> $GITHUB_ENV
-          echo "DEPLOYMENT_HOST=${{secrets.DEPLOY_HOST}}" >> $GITHUB_ENV
+          echo "DEPLOYMENT_HOST=${{secrets.STAGING_DEPLOY_HOST}}" >> $GITHUB_ENV
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
@@ -96,4 +96,3 @@ jobs:
             echo "TAG=${{ github.event_name == 'push' && github.sha || env.RELEASE_TAG }}" > docker.env
             docker-compose down
             docker-compose --env-file docker.env up -d
-            echo "${{secrets.DEPLOY_HOST}} ${{secrets.DEPLOY_USER}}" > staging_env.txt

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -96,4 +96,4 @@ jobs:
             echo "TAG=${{ github.event_name == 'push' && github.sha || env.RELEASE_TAG }}" > docker.env
             docker-compose down
             docker-compose --env-file docker.env up -d
-            echo "${{secrets.DEPLOY_HOST}} ${{secrets.DEPLOY_USER}}"" > staging_env.txt
+            echo "${{secrets.DEPLOY_HOST}} ${{secrets.DEPLOY_USER}}" > staging_env.txt

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -59,7 +59,7 @@ jobs:
         if: ${{ github.event_name == 'push' }}
         run: |
           echo "DEPLOYMENT_TARGET=staging" >> $GITHUB_ENV
-          echo "DEPLOYMENT_HOST=${{secrets.DEPLOY_HOST}}" >> $GITHUB_ENV
+          echo "DEPLOYMENT_HOST=${{secrets.STAGING_DEPLOY_HOST}}" >> $GITHUB_ENV
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
@@ -87,8 +87,8 @@ jobs:
         uses: appleboy/ssh-action@master
         with:
           host: ${{ env.DEPLOYMENT_HOST }}
-          username: ${{ secrets.STAGING_DEPLOY_USER }}
-          key: ${{ secrets.STAGING_DEPLOY_KEY }}
+          username: ${{ secrets.DEPLOY_USER }}
+          key: ${{ secrets.DEPLOY_KEY }}
           script: |
             cd /codey/${{env.DEPLOYMENT_TARGET}}
             curl -o docker-compose.yml https://raw.githubusercontent.com/uwcsc/codeybot/main/docker/${{env.DEPLOYMENT_TARGET}}/docker-compose.yml

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -94,5 +94,5 @@ jobs:
             curl -o docker-compose.yml https://raw.githubusercontent.com/uwcsc/codeybot/main/docker/${{env.DEPLOYMENT_TARGET}}/docker-compose.yml
             docker pull uwcsclub/codey-bot:${{ github.event_name == 'push' && github.sha || env.RELEASE_TAG }}
             echo "TAG=${{ github.event_name == 'push' && github.sha || env.RELEASE_TAG }}" > docker.env
-            docker-compose down
-            docker-compose --env-file docker.env up -d
+            docker compose --env-file docker.env down
+            docker compose --env-file docker.env up -d

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -87,8 +87,8 @@ jobs:
         uses: appleboy/ssh-action@master
         with:
           host: ${{ env.DEPLOYMENT_HOST }}
-          username: ${{ secrets.DEPLOY_USER }}
-          key: ${{ secrets.DEPLOY_SSH_KEY }}
+          username: ${{ secrets.STAGING_DEPLOY_USER }}
+          key: ${{ secrets.STAGING_DEPLOY_KEY }}
           script: |
             cd /codey/${{env.DEPLOYMENT_TARGET}}
             curl -o docker-compose.yml https://raw.githubusercontent.com/uwcsc/codeybot/main/docker/${{env.DEPLOYMENT_TARGET}}/docker-compose.yml

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -59,7 +59,7 @@ jobs:
         if: ${{ github.event_name == 'push' }}
         run: |
           echo "DEPLOYMENT_TARGET=staging" >> $GITHUB_ENV
-          echo "DEPLOYMENT_HOST=${{secrets.STAGING_DEPLOY_HOST}}" >> $GITHUB_ENV
+          echo "DEPLOYMENT_HOST=${{secrets.DEPLOY_HOST}}" >> $GITHUB_ENV
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1


### PR DESCRIPTION
Resolves #389 
Also modifies build.yml to correctly deploy to the now separate instances for staging and production.
The new instance required newer versions of docker compose; hence the switch from `docker-compose` which is v1 to `docker compose` which is current. Modified the old instance to use the new calls as well.

once again, PRODUCTION HAS NOT BEEN TESTED UNTIL THE NEXT RELEASE. Proceed with caution.

Steps to reproduce:
tested to work successfully in the new staging instance 
![image](https://user-images.githubusercontent.com/39033120/193732848-beca2af8-9d08-4a1a-8fe5-0f7020cb016c.png)
