### PR TITLE
Fixed position #0 in coin leaderboard

### DIFF
--- a/src/commandDetails/coin/info.ts
+++ b/src/commandDetails/coin/info.ts
@@ -42,7 +42,7 @@ const coinInfoExecuteCommand: SapphireMessageExecuteType = async (
 export const coinInfoCommandDetails: CodeyCommandDetails = {
   name: 'info',
   aliases: ['information, i'],
-  description: 'Get info about CodeyCoin.',
+  description: 'Get info about Codey coin.',
   detailedDescription: `**Examples:**
 \`${container.botPrefix}coin info\`
 \`${container.botPrefix}coin information\`

--- a/src/commands/coin/coin.ts
+++ b/src/commands/coin/coin.ts
@@ -3,7 +3,7 @@ import { CodeyCommand, CodeyCommandDetails } from '../../codeyCommand';
 import { coinAdjustCommandDetails } from '../../commandDetails/coin/adjust';
 import { coinCheckCommandDetails } from '../../commandDetails/coin/check';
 import { coinInfoCommandDetails } from '../../commandDetails/coin/info';
-import { coinCurrentLeaderboardCommandDetails } from '../../commandDetails/coin/leaderboard';
+import { coinLeaderboardCommandDetails } from '../../commandDetails/coin/leaderboard';
 import { coinUpdateCommandDetails } from '../../commandDetails/coin/update';
 
 const coinCommandDetails: CodeyCommandDetails = {
@@ -26,7 +26,7 @@ const coinCommandDetails: CodeyCommandDetails = {
     check: coinCheckCommandDetails,
     info: coinInfoCommandDetails,
     update: coinUpdateCommandDetails,
-    leaderboard: coinCurrentLeaderboardCommandDetails,
+    leaderboard: coinLeaderboardCommandDetails,
   },
   defaultSubcommandDetails: coinCheckCommandDetails,
 };

--- a/src/commands/profile/profile.ts
+++ b/src/commands/profile/profile.ts
@@ -69,7 +69,7 @@ export class ProfileCommand extends SubCommandPluginCommand {
           );
         }
       }
-      // add codeycoins onto the fields as well
+      // add Codey coins onto the fields as well
       const userCoins = (await getCoinBalanceByUserId(user.id))!.toString();
       profileDisplay.addField('Codey Coins', userCoins, true);
       // display last updated last

--- a/src/components/coin.ts
+++ b/src/components/coin.ts
@@ -146,16 +146,17 @@ export const changeDbCoinBalanceByUserId = async (
 /*
   Get the leaderboard for the current coin amounts.
 */
-export const getCurrentCoinLeaderboard = async (limit = 10): Promise<UserCoinEntry[]> => {
+export const getCoinLeaderboard = async (limit: number, offset = 0): Promise<UserCoinEntry[]> => {
   const db = await openDB();
   const res = await db.all(
     `
       SELECT user_id, balance
       FROM user_coin
       ORDER BY balance DESC
-      LIMIT ?
+      LIMIT ? OFFSET ?
     `,
     limit,
+    offset,
   );
   return res;
 };


### PR DESCRIPTION
## Summary of Changes
<!-- A summary or description of changes made in this PR. -->
- Fixed the bug where a user who is not on the coin leaderboard would have position #0
- Stylized `CodeyCoin` as `Codey coin`
- Removed the word "current" from the naming related to the coin leaderboard; if more leaderboards are to be added later, then adjectives can be added just for those

## Motivation and Explanation
<!-- How and why do your changes improve the bot? -->
This fix would let a user see their correct position

## Related Issues
<!-- Issue(s) that this PR will resolve, e.g. "resolves <issue link here>". -->
Resolves #419 

## Steps to Reproduce
<!-- List the steps needed for the reviewer to produce your PR changes. -->
Try `.coin lb` when you are not on the coin leaderboard

## Demonstration of Changes
<!-- If applicable, include screenshots to illustrate your new feature or fix. -->
Without ties:
![image](https://user-images.githubusercontent.com/58180935/209425058-03509617-9659-448e-83dd-b46e1e880fdf.png)

With ties:
![image](https://user-images.githubusercontent.com/58180935/209425071-08d3a0ca-0794-4996-8ad4-6a422e534056.png)

## Further Information and Comments

