### PR TITLE
434 leetcode for codey

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "sqlite": "^4.0.22",
     "sqlite3": "^5.0.2",
     "stable-marriage": "^1.0.2",
+    "turndown": "^7.1.1",
     "typescript": "^4.6.3",
     "winston": "^3.8.1"
   },
@@ -51,6 +52,7 @@
     "@types/lodash": "^4.14.168",
     "@types/node": "^15.0.1",
     "@types/sqlite3": "^3.1.7",
+    "@types/turndown": "^5.0.1",
     "@typescript-eslint/eslint-plugin": "^4.22.0",
     "@typescript-eslint/parser": "^4.22.0",
     "eslint": "^7.25.0",

--- a/src/commandDetails/leetcode/leetcodeRandomCommandDetails.ts
+++ b/src/commandDetails/leetcode/leetcodeRandomCommandDetails.ts
@@ -10,39 +10,32 @@ import { CodeyUserError } from '../../codeyUserError';
 import {
   getMessageForLeetcodeProblem,
   getLeetcodeProblemDataFromId,
+  totalNumberOfLeetcodeProblems,
 } from '../../components/leetcode';
+import { getRandomIntFrom1 } from '../../utils/num';
 
 // Check a user's balance
-const leetcodeSpecificExecuteCommand: SapphireMessageExecuteType = async (
+const leetcodeRandomExecuteCommand: SapphireMessageExecuteType = async (
   _client,
   messageFromUser,
   args,
 ): Promise<SapphireMessageResponse> => {
-  const problemId = <number>args['problem-id'];
-  if (!Number.isInteger(problemId)) {
-    throw new CodeyUserError(messageFromUser, 'Problem ID must be an integer.');
-  }
+  const problemId = getRandomIntFrom1(totalNumberOfLeetcodeProblems);
   const result = await getLeetcodeProblemDataFromId(problemId);
 
   return getMessageForLeetcodeProblem(result);
 };
 
-export const leetcodeSpecificCommandDetails: CodeyCommandDetails = {
-  name: 'specific',
-  aliases: ['spec'],
-  description: 'Get a Leetcode problem with specified problem ID.',
+export const leetcodeRandomCommandDetails: CodeyCommandDetails = {
+  name: 'random',
+  aliases: ['random'],
+  description: 'Get a random Leetcode problem',
   detailedDescription: `**Examples:**
-\`${container.botPrefix}leetcode specific 1\``,
+\`${container.botPrefix}leetcode\`\n
+\`${container.botPrefix}leetcode random\``,
 
   isCommandResponseEphemeral: false,
-  executeCommand: leetcodeSpecificExecuteCommand,
-  options: [
-    {
-      name: 'problem-id',
-      description: 'The problem id for the Leetcode problem.',
-      type: CodeyCommandOptionType.NUMBER,
-      required: true,
-    },
-  ],
+  executeCommand: leetcodeRandomExecuteCommand,
+  options: [],
   subcommandDetails: {},
 };

--- a/src/commandDetails/leetcode/leetcodeRandomCommandDetails.ts
+++ b/src/commandDetails/leetcode/leetcodeRandomCommandDetails.ts
@@ -5,7 +5,6 @@ import {
   CodeyCommandOptionType,
   SapphireAfterReplyType,
   SapphireMessageExecuteType,
-  SapphireMessageResponse,
   SapphireMessageResponseWithMetadata,
 } from '../../codeyCommand';
 import { CodeyUserError } from '../../codeyUserError';
@@ -37,7 +36,7 @@ const leetcodeRandomExecuteCommand: SapphireMessageExecuteType = async (
 
 const leetcodeRandomAfterMessageReply: SapphireAfterReplyType = async (
   result,
-  sentMessage,
+  _sentMessage,
 ): Promise<unknown> => {
   // The API might take more than 3 seconds to complete
   // Which is more than the timeout for slash commands

--- a/src/commandDetails/leetcode/leetcodeRandomCommandDetails.ts
+++ b/src/commandDetails/leetcode/leetcodeRandomCommandDetails.ts
@@ -14,11 +14,10 @@ import {
   createInitialValuesForTags,
   getListOfLeetcodeProblemIds,
   LeetcodeDifficulty,
-  totalNumberOfProblems,
+  TOTAL_NUMBER_OF_PROBLEMS,
 } from '../../components/leetcode';
 import { getRandomIntFrom1 } from '../../utils/num';
 
-// Check a user's balance
 const leetcodeRandomExecuteCommand: SapphireMessageExecuteType = async (
   _client,
   messageFromUser,
@@ -49,7 +48,7 @@ const leetcodeRandomAfterMessageReply: SapphireAfterReplyType = async (
 
   let problemId;
   if (typeof difficulty === 'undefined' && typeof tag === 'undefined') {
-    problemId = getRandomIntFrom1(totalNumberOfProblems);
+    problemId = getRandomIntFrom1(TOTAL_NUMBER_OF_PROBLEMS);
   } else {
     const problemIds = await getListOfLeetcodeProblemIds(difficulty, tag);
     const index = getRandomIntFrom1(problemIds.length) - 1;
@@ -67,8 +66,8 @@ const leetcodeRandomAfterMessageReply: SapphireAfterReplyType = async (
 
 export const leetcodeRandomCommandDetails: CodeyCommandDetails = {
   name: 'random',
-  aliases: ['random'],
-  description: 'Get a random Leetcode problem',
+  aliases: ['r'],
+  description: 'Get a random LeetCode problem.',
   detailedDescription: `**Examples:**
 \`${container.botPrefix}leetcode\`\n
 \`${container.botPrefix}leetcode random\``,
@@ -79,7 +78,7 @@ export const leetcodeRandomCommandDetails: CodeyCommandDetails = {
   options: [
     {
       name: 'difficulty',
-      description: 'The difficulty of the problem to filter by if specified.',
+      description: 'The difficulty of the problem.',
       type: CodeyCommandOptionType.STRING,
       required: false,
       choices: [
@@ -90,7 +89,7 @@ export const leetcodeRandomCommandDetails: CodeyCommandDetails = {
     },
     {
       name: 'tag',
-      description: 'The type of problem to filter by if specified.',
+      description: 'The type of problem.',
       type: CodeyCommandOptionType.STRING,
       required: false,
       choices: createInitialValuesForTags(),

--- a/src/commandDetails/leetcode/leetcodeSpecificCommandDetails.ts
+++ b/src/commandDetails/leetcode/leetcodeSpecificCommandDetails.ts
@@ -1,0 +1,43 @@
+import { container } from '@sapphire/framework';
+import { User } from 'discord.js';
+import {
+  CodeyCommandDetails,
+  CodeyCommandOptionType,
+  SapphireMessageExecuteType,
+  SapphireMessageResponse,
+} from '../../codeyCommand';
+import { CodeyUserError } from '../../codeyUserError';
+import { getLeetcodeProblemDataFromId } from '../../components/leetcode';
+
+// Check a user's balance
+const leetcodeSpecificExecuteCommand: SapphireMessageExecuteType = async (
+  _client,
+  messageFromUser,
+  args,
+): Promise<SapphireMessageResponse> => {
+  const problemId = <number>args['problem-id'];
+  if (!Number.isInteger(problemId)) {
+    throw new CodeyUserError(messageFromUser, 'Problem ID must be an integer.');
+  }
+  let result = await getLeetcodeProblemDataFromId(problemId);
+};
+
+export const leetcodeSpecificCommandDetails: CodeyCommandDetails = {
+  name: 'specific',
+  aliases: ['spec'],
+  description: 'Get a Leetcode problem with specified problem ID.',
+  detailedDescription: `**Examples:**
+\`${container.botPrefix}leetcode specific 1\``,
+
+  isCommandResponseEphemeral: false,
+  executeCommand: leetcodeSpecificExecuteCommand,
+  options: [
+    {
+      name: 'problem-id',
+      description: 'The problem id for the Leetcode problem.',
+      type: CodeyCommandOptionType.NUMBER,
+      required: true,
+    },
+  ],
+  subcommandDetails: {},
+};

--- a/src/commandDetails/leetcode/leetcodeSpecificCommandDetails.ts
+++ b/src/commandDetails/leetcode/leetcodeSpecificCommandDetails.ts
@@ -1,5 +1,4 @@
 import { container } from '@sapphire/framework';
-import { User } from 'discord.js';
 import {
   CodeyCommandDetails,
   CodeyCommandOptionType,

--- a/src/commandDetails/leetcode/leetcodeSpecificCommandDetails.ts
+++ b/src/commandDetails/leetcode/leetcodeSpecificCommandDetails.ts
@@ -16,7 +16,7 @@ const leetcodeSpecificExecuteCommand: SapphireMessageExecuteType = async (
   messageFromUser,
   args,
 ): Promise<SapphireMessageResponse> => {
-  const problemId = <number>args['problem-id'];
+  const problemId = <number>args['problem-ID'];
   if (!Number.isInteger(problemId)) {
     throw new CodeyUserError(messageFromUser, 'Problem ID must be an integer.');
   }
@@ -37,7 +37,7 @@ export const leetcodeSpecificCommandDetails: CodeyCommandDetails = {
   options: [
     {
       name: 'problem-ID',
-      description: 'The problem id.',
+      description: 'The problem ID.',
       type: CodeyCommandOptionType.NUMBER,
       required: true,
     },

--- a/src/commandDetails/leetcode/leetcodeSpecificCommandDetails.ts
+++ b/src/commandDetails/leetcode/leetcodeSpecificCommandDetails.ts
@@ -11,7 +11,6 @@ import {
   getLeetcodeProblemDataFromId,
 } from '../../components/leetcode';
 
-// Check a user's balance
 const leetcodeSpecificExecuteCommand: SapphireMessageExecuteType = async (
   _client,
   messageFromUser,
@@ -28,8 +27,8 @@ const leetcodeSpecificExecuteCommand: SapphireMessageExecuteType = async (
 
 export const leetcodeSpecificCommandDetails: CodeyCommandDetails = {
   name: 'specific',
-  aliases: ['spec'],
-  description: 'Get a Leetcode problem with specified problem ID.',
+  aliases: ['spec', 's'],
+  description: 'Get a LeetCode problem with specified problem ID.',
   detailedDescription: `**Examples:**
 \`${container.botPrefix}leetcode specific 1\``,
 
@@ -37,8 +36,8 @@ export const leetcodeSpecificCommandDetails: CodeyCommandDetails = {
   executeCommand: leetcodeSpecificExecuteCommand,
   options: [
     {
-      name: 'problem-id',
-      description: 'The problem id for the Leetcode problem.',
+      name: 'problem-ID',
+      description: 'The problem id.',
       type: CodeyCommandOptionType.NUMBER,
       required: true,
     },

--- a/src/commands/leetcode/leetcode.ts
+++ b/src/commands/leetcode/leetcode.ts
@@ -1,0 +1,29 @@
+import { Command, container } from '@sapphire/framework';
+import { CodeyCommand, CodeyCommandDetails } from '../../codeyCommand';
+import { leetcodeSpecificCommandDetails } from '../../commandDetails/leetcode/leetcodeSpecificCommandDetails';
+
+const leetcodeCommandDetails: CodeyCommandDetails = {
+  name: 'leetcode',
+  aliases: [],
+  description: 'Handle coin functions.',
+  detailedDescription: ``, // leave blank for now
+  options: [],
+  subcommandDetails: {
+    // random
+    specific: leetcodeSpecificCommandDetails,
+  },
+  defaultSubcommandDetails: leetcodeSpecificCommandDetails,
+};
+
+export class LeetcodeCommand extends CodeyCommand {
+  details = leetcodeCommandDetails;
+
+  public constructor(context: Command.Context, options: Command.Options) {
+    super(context, {
+      ...options,
+      aliases: leetcodeCommandDetails.aliases,
+      description: leetcodeCommandDetails.description,
+      detailedDescription: leetcodeCommandDetails.detailedDescription,
+    });
+  }
+}

--- a/src/commands/leetcode/leetcode.ts
+++ b/src/commands/leetcode/leetcode.ts
@@ -1,5 +1,6 @@
 import { Command, container } from '@sapphire/framework';
 import { CodeyCommand, CodeyCommandDetails } from '../../codeyCommand';
+import { leetcodeRandomCommandDetails } from '../../commandDetails/leetcode/leetcodeRandomCommandDetails';
 import { leetcodeSpecificCommandDetails } from '../../commandDetails/leetcode/leetcodeSpecificCommandDetails';
 
 const leetcodeCommandDetails: CodeyCommandDetails = {
@@ -9,10 +10,10 @@ const leetcodeCommandDetails: CodeyCommandDetails = {
   detailedDescription: ``, // leave blank for now
   options: [],
   subcommandDetails: {
-    // random
+    random: leetcodeRandomCommandDetails,
     specific: leetcodeSpecificCommandDetails,
   },
-  defaultSubcommandDetails: leetcodeSpecificCommandDetails,
+  defaultSubcommandDetails: leetcodeRandomCommandDetails,
 };
 
 export class LeetcodeCommand extends CodeyCommand {

--- a/src/commands/leetcode/leetcode.ts
+++ b/src/commands/leetcode/leetcode.ts
@@ -6,7 +6,7 @@ import { leetcodeSpecificCommandDetails } from '../../commandDetails/leetcode/le
 const leetcodeCommandDetails: CodeyCommandDetails = {
   name: 'leetcode',
   aliases: [],
-  description: 'Handle coin functions.',
+  description: 'Handle LeetCode functions.',
   detailedDescription: ``, // leave blank for now
   options: [],
   subcommandDetails: {

--- a/src/commands/leetcode/leetcode.ts
+++ b/src/commands/leetcode/leetcode.ts
@@ -1,4 +1,4 @@
-import { Command, container } from '@sapphire/framework';
+import { Command } from '@sapphire/framework';
 import { CodeyCommand, CodeyCommandDetails } from '../../codeyCommand';
 import { leetcodeRandomCommandDetails } from '../../commandDetails/leetcode/leetcodeRandomCommandDetails';
 import { leetcodeSpecificCommandDetails } from '../../commandDetails/leetcode/leetcodeSpecificCommandDetails';

--- a/src/components/leetcode.ts
+++ b/src/components/leetcode.ts
@@ -81,11 +81,6 @@ interface LeetcodeProblemData {
   problemId: number;
 }
 
-interface LeetcodeProblemQuery {
-  difficulty: LeetcodeDifficulty;
-  tags: string;
-}
-
 export const createInitialValuesForTags = (): APIApplicationCommandOptionChoice[] => {
   return [
     ...Object.entries(LeetcodeTagsDict).map((e) => {

--- a/src/components/leetcode.ts
+++ b/src/components/leetcode.ts
@@ -1,0 +1,70 @@
+import axios from 'axios';
+import { convertHtmlToMarkdown } from '../utils/markdown';
+
+const leetcodeIdUrl = 'https://lcid.cc/info';
+const leetcodeUrl = 'https://leetcode.com/graphql';
+
+interface LeetcodeTopicTag {
+  name: string;
+}
+
+interface LeetcodeIdProblemDataFromUrl {
+  difficulty: 'Easy' | 'Medium' | 'Hard';
+  likes: number;
+  dislikes: number;
+  categoryTitle: string;
+  frontendQuestionId: number;
+  paidOnly: boolean;
+  title: string;
+  titleSlug: string;
+  topicTags: LeetcodeTopicTag[];
+  totalAcceptedRaw: number;
+  totalSubmissionRaw: number;
+}
+
+interface LeetcodeProblemDataFromUrl {
+  data: {
+    question: {
+      content: string;
+    };
+  };
+}
+
+interface LeetcodeProblemData {
+  difficulty: 'Easy' | 'Medium' | 'Hard';
+  likes: number;
+  dislikes: number;
+  categoryTitle: string;
+  paidOnly: boolean;
+  title: string;
+  topicTags: LeetcodeTopicTag[];
+  totalAcceptedRaw: number;
+  totalSubmissionRaw: number;
+  contentAsMarkdown: string;
+}
+
+export const getLeetcodeProblemDataFromId = async (
+  problemId: number,
+): Promise<LeetcodeProblemData> => {
+  const resFromLeetcodeById: LeetcodeIdProblemDataFromUrl = (
+    await axios.get(`${leetcodeIdUrl}/${problemId}`)
+  ).data;
+  const resFromLeetcode: LeetcodeProblemDataFromUrl = (
+    await axios.get(leetcodeUrl, {
+      params: {
+        operationName: 'questionData',
+        variables: {
+          titleSlug: resFromLeetcodeById.titleSlug,
+        },
+        query:
+          'query questionData($titleSlug: String!) {\n  question(titleSlug: $titleSlug) {\n    questionId\n    questionFrontendId\n    boundTopicId\n    title\n    titleSlug\n    content\n    translatedTitle\n    translatedContent\n    isPaidOnly\n    difficulty\n    likes\n    dislikes\n    isLiked\n    similarQuestions\n    contributors {\n      username\n      profileUrl\n      avatarUrl\n      __typename\n    }\n    langToValidPlayground\n    topicTags {\n      name\n      slug\n      translatedName\n      __typename\n    }\n    companyTagStats\n    codeSnippets {\n      lang\n      langSlug\n      code\n      __typename\n    }\n    stats\n    hints\n    solution {\n      id\n      canSeeDetail\n      __typename\n    }\n    status\n    sampleTestCase\n    metaData\n    judgerAvailable\n    judgeType\n    mysqlSchemas\n    enableRunCode\n    enableTestMode\n    envInfo\n    libraryUrl\n    __typename\n  }\n}\n',
+      },
+    })
+  ).data;
+
+  const result: LeetcodeProblemData = {
+    ...resFromLeetcodeById,
+    contentAsMarkdown: convertHtmlToMarkdown(resFromLeetcode.data.question.content),
+  };
+  return result;
+};

--- a/src/components/leetcode.ts
+++ b/src/components/leetcode.ts
@@ -6,12 +6,92 @@ const leetcodeIdUrl = 'https://lcid.cc/info';
 const leetcodeApiUrl = 'https://leetcode.com/graphql';
 const leetcodeUrl = 'https://leetcode.com/problems';
 
+const LeetcodeTagsDict = {
+  array: 'Array',
+  string: 'String',
+  'hash-table': 'Hash Table',
+  'dynamic-programming': 'Dynamic Programming',
+  math: 'Math',
+  sorting: 'Sorting',
+  greedy: 'Greedy',
+  'depth-first-search': 'Depth-First Search',
+  database: 'Database',
+  'binary-search': 'Binary Search',
+  'breadth-first-search': 'Breadth-First Search',
+  tree: 'Tree',
+  matrix: 'Matrix',
+  'binary-tree': 'Binary Tree',
+  'two-pointers': 'Two Pointers',
+  'bit-manipulation': 'Bit Manipulation',
+  stack: 'Stack',
+  'heap-priority-queue': 'Heap (Priority Queue)',
+  graph: 'Graph',
+  design: 'Design',
+  'prefix-sum': 'Prefix Sum',
+  simulation: 'Simulation',
+  counting: 'Counting',
+  backtracking: 'Backtracking',
+  'sliding-window': 'Sliding Window',
+  'union-find': 'Union Find',
+  'linked-list': 'Linked List',
+  'ordered-set': 'Ordered Set',
+  'monotonic-stack': 'Monotonic Stack',
+  enumeration: 'Enumeration',
+  recursion: 'Recursion',
+  trie: 'Trie',
+  'divide-and-conquer': 'Divide and Conquer',
+  'binary-search-tree': 'Binary Search Tree',
+  queue: 'Queue',
+  bitmask: 'Bitmask',
+  memoization: 'Memoization',
+  geometry: 'Geometry',
+  'segment-tree': 'Segment Tree',
+  'topological-sort': 'Topological Sort',
+  'number-theory': 'Number Theory',
+  'binary-indexed-tree': 'Binary Indexed Tree',
+  'hash-function': 'Hash Function',
+  'game-theory': 'Game Theory',
+  combinatorics: 'Combinatorics',
+  'shortest-path': 'Shortest Path',
+  'data-stream': 'Data Stream',
+  interactive: 'Interactive',
+  'string-matching': 'String Matching',
+  'rolling-hash': 'Rolling Hash',
+  randomized: 'Randomized',
+  brainteaser: 'Brainteaser',
+  'monotonic-queue': 'Monotonic Queue',
+  'merge-sort': 'Merge Sort',
+  iterator: 'Iterator',
+  concurrency: 'Concurrency',
+  'doubly-linked-list': 'Doubly-Linked List',
+  'probability-and-statistics': 'Probability and Statistics',
+  quickselect: 'Quickselect',
+  'bucket-sort': 'Bucket Sort',
+  'suffix-array': 'Suffix Array',
+  'minimum-spanning-tree': 'Minimum Spanning Tree',
+  'counting-sort': 'Counting Sort',
+  shell: 'Shell',
+  'line-sweep': 'Line Sweep',
+  'reservoir-sampling': 'Reservoir Sampling',
+  'eulerian-circuit': 'Eulerian Circuit',
+  'radix-sort': 'Radix Sort',
+  'strongly-connected-component': 'Strongly Connected Component',
+  'rejection-sampling': 'Rejection Sampling',
+  'biconnected-component': 'Biconnected Component',
+};
+
 interface LeetcodeTopicTag {
   name: string;
 }
 
+enum LeetcodeDifficulty {
+  'Easy',
+  'Medium',
+  'Hard',
+}
+
 interface LeetcodeIdProblemDataFromUrl {
-  difficulty: 'Easy' | 'Medium' | 'Hard';
+  difficulty: LeetcodeDifficulty;
   likes: number;
   dislikes: number;
   categoryTitle: string;
@@ -33,7 +113,7 @@ interface LeetcodeProblemDataFromUrl {
 }
 
 interface LeetcodeProblemData {
-  difficulty: 'Easy' | 'Medium' | 'Hard';
+  difficulty: LeetcodeDifficulty;
   likes: number;
   dislikes: number;
   categoryTitle: string;
@@ -47,8 +127,10 @@ interface LeetcodeProblemData {
   problemId: number;
 }
 
-// I couldn't find a way to get this dynamically, so a constant suffices for now
-export const totalNumberOfLeetcodeProblems = 2577;
+interface LeetcodeProblemQuery {
+  difficulty: LeetcodeDifficulty;
+  tags: string;
+}
 
 export const getLeetcodeProblemDataFromId = async (
   problemId: number,

--- a/src/components/leetcode.ts
+++ b/src/components/leetcode.ts
@@ -2,6 +2,8 @@ import axios from 'axios';
 import { APIApplicationCommandOptionChoice } from 'discord-api-types/v9';
 import { convertHtmlToMarkdown } from '../utils/markdown';
 
+export const TOTAL_NUMBER_OF_PROBLEMS = 2577;
+
 const leetcodeIdUrl = 'https://lcid.cc/info';
 const leetcodeApiUrl = 'https://leetcode.com/graphql';
 const leetcodeUrl = 'https://leetcode.com/problems';
@@ -148,8 +150,6 @@ export const getListOfLeetcodeProblemIds = async (
   );
   return result;
 };
-
-export const totalNumberOfProblems = 2577;
 
 export const getMessageForLeetcodeProblem = (leetcodeProblemData: LeetcodeProblemData): string => {
   const title = `#${leetcodeProblemData.problemId}: ${leetcodeProblemData.title}`;

--- a/src/utils/markdown.ts
+++ b/src/utils/markdown.ts
@@ -1,0 +1,6 @@
+import TurndownService from 'turndown';
+
+export const convertHtmlToMarkdown = (html: string): string => {
+  const turndownService = new TurndownService();
+  return turndownService.turndown(html);
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -372,6 +372,11 @@
   dependencies:
     "@types/node" "*"
 
+"@types/turndown@^5.0.1":
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/@types/turndown/-/turndown-5.0.1.tgz#fcda7b02cda4c9d445be1440036df20f335b9387"
+  integrity sha512-N8Ad4e3oJxh9n9BiZx9cbe/0M3kqDpOTm2wzj13wdDUxDPjfjloWIJaquZzWE1cYTAHpjOH3rcTnXQdpEfS/SQ==
+
 "@types/ws@^8.5.3":
   version "8.5.3"
   resolved "https://registry.yarnpkg.com/@types/ws/-/ws-8.5.3.tgz#7d25a1ffbecd3c4f2d35068d0b283c037003274d"
@@ -916,6 +921,11 @@ doctrine@^3.0.0:
   integrity sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==
   dependencies:
     esutils "^2.0.2"
+
+domino@^2.1.6:
+  version "2.1.6"
+  resolved "https://registry.yarnpkg.com/domino/-/domino-2.1.6.tgz#fe4ace4310526e5e7b9d12c7de01b7f485a57ffe"
+  integrity sha512-3VdM/SXBZX2omc9JF9nOPCtDaYQ67BGp5CoLpIQlO2KCAPETs8TcDHacF26jXadGbvUteZzRTeos2fhID5+ucQ==
 
 dotenv@^8.2.0:
   version "8.6.0"
@@ -2408,6 +2418,13 @@ tsutils@^3.21.0:
   integrity sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==
   dependencies:
     tslib "^1.8.1"
+
+turndown@^7.1.1:
+  version "7.1.1"
+  resolved "https://registry.yarnpkg.com/turndown/-/turndown-7.1.1.tgz#96992f2d9b40a1a03d3ea61ad31b5a5c751ef77f"
+  integrity sha512-BEkXaWH7Wh7e9bd2QumhfAXk5g34+6QUmmWx+0q6ThaVOLuLUqsnkq35HQ5SBHSaxjSfSM7US5o4lhJNH7B9MA==
+  dependencies:
+    domino "^2.1.6"
 
 type-check@^0.4.0, type-check@~0.4.0:
   version "0.4.0"


### PR DESCRIPTION
## Summary of Changes

Added commands for leetcode:
```
.leetcode / .leetcode random [difficulty] [tag] -> Generates a random Leetcode problem with an optional filter for difficulty and tag.
.leetcode specific [problem id] -> Generates a Leetcode problem with specified ID.
```

## Motivation and Explanation

Leetcode Bot became broken - this functionality should replace it.

## Related Issues

Resolves #434 

## Steps to Reproduce

Use the commands specified above.

## Demonstration of Changes

![image](https://user-images.githubusercontent.com/76544623/222871432-44616191-7a34-47f4-ab65-e746b492efeb.png)
![image](https://user-images.githubusercontent.com/76544623/222871457-cef72683-e2eb-475b-922b-fb6315670ce6.png)
![image](https://user-images.githubusercontent.com/76544623/222871473-ddcee023-d3de-4d7a-9753-b08a9c304a5d.png)
![image](https://user-images.githubusercontent.com/76544623/222871482-8dbbeb20-2946-4e93-9c45-8a67dc740ffc.png)

## Further Information and Comments

- The Leetcode "API" might take longer than 3 seconds to run, which is the timeout for slash commands. So, instead of sending the problem via the original command, we send it as a followup message using the `afterMessageReply` functionality.
- The command is significantly faster for a search for a random problem or by a specific id compared to using filters.