### PR TITLE
Coin Transfer Bug Fixes

### DIFF
--- a/src/components/coin.ts
+++ b/src/components/coin.ts
@@ -382,10 +382,7 @@ export class Transfer {
     const senderBalance = await getCoinBalanceByUserId(this.state.sender.id);
     if (this.state.amount > senderBalance) {
       this.state.result = TransferResult.Invalid;
-      return;
-    }
-
-    if (this.state.result === TransferResult.Confirmed) {
+    } else if (this.state.result === TransferResult.Confirmed) {
       // Adjust the receiver balance with coins transferred
       await adjustCoinBalanceByUserId(
         this.state.receiver.id,

--- a/src/components/coin.ts
+++ b/src/components/coin.ts
@@ -433,7 +433,7 @@ export class Transfer {
           this.state.sender.username
         } now has ${newSenderBalance} Codey ${pluralize(
           'coin',
-          newReceiverBalance,
+          newSenderBalance,
         )} ${getCoinEmoji()}.`;
       case TransferResult.Rejected:
         return `This transfer was rejected by ${this.state.receiver.username}.`;


### PR DESCRIPTION
## Summary of Changes
Added sender balance check at time of transfer handling, added enum value `Invalid` for TransferResult.

Also fixes mistake where newReceiverBalance was passed to the pluralize call for newSenderBalance.

## Motivation and Explanation
Fixes bug where sender can start a transfer, lose coins so that they have fewer than the amount to be transferred, but still have the transfer go through. Previously the command only checked if the sender had enough at the start. 

## Related Issues
Issue was closed, but issue#-307

## Demonstration of Changes
![image](https://user-images.githubusercontent.com/69977136/223588425-98606fe6-c33c-4b43-9760-9a5655d5cb72.png)


