### PR TITLE
Logging changed to work with codey user error in case of slash commands

### DIFF
--- a/src/codeyCommand.ts
+++ b/src/codeyCommand.ts
@@ -299,13 +299,14 @@ export class CodeyCommand extends SapphireCommand {
         return await message.reply(<string | MessagePayload>successResponse);
       }
     } catch (e) {
-      logger.error(e);
       if (e instanceof CodeyUserError) {
         if (!e.message) {
           e.message = message;
         }
+        logger.error(e.errorMessage);
         e.sendToUser();
       } else {
+        logger.error(e);
         message.reply(commandDetails.messageIfFailure ?? defaultBackendErrorMessage);
       }
     }
@@ -390,13 +391,14 @@ export class CodeyCommand extends SapphireCommand {
         }
       }
     } catch (e) {
-      logger.error(e);
       if (e instanceof CodeyUserError) {
+        logger.error(e.errorMessage);
         if (!e.message) {
           e.message = interaction;
         }
         e.sendToUser();
       } else {
+        logger.error(e);
         return await interaction.editReply(
           commandDetails.messageIfFailure ?? defaultBackendErrorMessage,
         );


### PR DESCRIPTION
## Summary of Changes
Fixing CodeyUserError to work with slash commands. Just needed to change the logging method because logging CodeyUserError with message undefined is failing JSON.stringify so only printing the error message in case of CodeyUserError. 

## Motivation and Explanation
Fixing CodeyUserError to work with slash commands. 

## Related Issues


## Steps to Reproduce
Run a slash command with some validation error. 
See that the error is shown.

## Demonstration of Changes
<img width="832" alt="image" src="https://user-images.githubusercontent.com/84613574/229736290-4b196cf0-abc5-4b5a-be6f-c3c1ee9dcf09.png">


## Further Information and Comments

