### PR TITLE
Stop bot from dying if a non-PDF file is posted in the resume channel

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -1,6 +1,7 @@
 import { readFileSync } from 'fs';
 
 export const ENV: string = process.env.NODE_ENV || 'dev';
+
 export const vars: Record<string, string> = JSON.parse(
   readFileSync(`./config/${ENV}/vars.json`, 'utf-8'),
 );


### PR DESCRIPTION
## Summary of Changes
<!-- A summary or description of changes made in this PR. -->
- The bot does not crash anymore if a non-PDF file is posted in the resume channel
- Move reused hard-coded string into a constant

## Motivation and Explanation
<!-- How and why do your changes improve the bot? -->
The bot not crashing is indisputably an improvement

## Related Issues
<!-- Issue(s) that this PR will resolve, e.g. "resolves <issue link here>". -->
Resolves #439 

## Steps to Reproduce
<!-- List the steps needed for the reviewer to produce your PR changes. -->
For example, post an image in the resume channel and the bot does not die anymore

## Demonstration of Changes
<!-- If applicable, include screenshots to illustrate your new feature or fix. -->

## Further Information and Comments

