### PR TITLE
Issue #484 - Remove discriminators from leaderboard

### DIFF
--- a/src/commandDetails/coin/leaderboard.ts
+++ b/src/commandDetails/coin/leaderboard.ts
@@ -53,6 +53,7 @@ const getCoinLeaderboardEmbed = async (
     if (userCoinEntry.user_id === userId) {
       position = rank;
     }
+    let sanitizedTag: string;
     if (leaderboardArray.length < LEADERBOARD_LIMIT_DISPLAY) {
       const userTag = user?.tag ?? '<unknown>';
       const cleanUserTag = userTag
@@ -64,7 +65,13 @@ const getCoinLeaderboardEmbed = async (
         .join('\\_')
         .split('`')
         .join('\\`');
-      const userCoinEntryText = `${rank}. ${cleanUserTag} - ${
+      if (cleanUserTag.endsWith("#0")) {
+      	sanitizedTag = cleanUserTag.substring(0, cleanUserTag.length - 2);
+      }
+      else {
+      	sanitizedTag = cleanUserTag;
+      }
+      const userCoinEntryText = `${rank}. ${sanitizedTag} - ${
         userCoinEntry.balance
       } ${getCoinEmoji()}`;
       leaderboardArray.push(userCoinEntryText);

--- a/src/commandDetails/coin/leaderboard.ts
+++ b/src/commandDetails/coin/leaderboard.ts
@@ -65,11 +65,10 @@ const getCoinLeaderboardEmbed = async (
         .join('\\_')
         .split('`')
         .join('\\`');
-      if (cleanUserTag.endsWith("#0")) {
-      	sanitizedTag = cleanUserTag.substring(0, cleanUserTag.length - 2);
-      }
-      else {
-      	sanitizedTag = cleanUserTag;
+      if (cleanUserTag.endsWith('#0')) {
+        sanitizedTag = cleanUserTag.substring(0, cleanUserTag.length - 2);
+      } else {
+        sanitizedTag = cleanUserTag;
       }
       const userCoinEntryText = `${rank}. ${sanitizedTag} - ${
         userCoinEntry.balance

--- a/src/commands/games/blackjack.ts
+++ b/src/commands/games/blackjack.ts
@@ -274,6 +274,7 @@ export class GamesBlackjackCommand extends Command {
           // if player has not acted within time limit, consider it as quitting the game
           game = await performGameAction(author.id, BlackjackAction.QUIT);
           message.reply("you didn't act within the time limit, please start another game!");
+          if (game) game.stage = BlackjackStage.DONE;
         }
       }
       if (game) {


### PR DESCRIPTION
## Summary of Changes
* Removes the fake #0 discriminator from users that have been assigned a Discord user id. Those that still have discriminators will keep them in the leaderboard.

## Motivation and Explanation
* Discord recently started migrating users with discriminators after their username to unique user IDs.

## Related Issues
* Solves #484.
* 
## Steps to Reproduce
* Run .coin leaderboard with a mix of users that have discriminators and those who don't. 

