### PR TITLE
Do not match someone with themself if only one user has coffeechat role

### DIFF
--- a/src/commands/coffeeChat/coffeeChat.ts
+++ b/src/commands/coffeeChat/coffeeChat.ts
@@ -17,9 +17,7 @@ export class CoffeeChatCommand extends Subcommand {
       name: 'coffee',
       description: 'Handle coffee chat functions.',
       detailedDescription: `**Examples:**
-\`${container.botPrefix}coffeechat match\`
 \`${container.botPrefix}coffee match\`
-\`${container.botPrefix}coffeechat test 5\`
 \`${container.botPrefix}coffee test 10\``,
       subcommands: [
         { name: 'match', messageRun: 'match' },
@@ -32,6 +30,8 @@ export class CoffeeChatCommand extends Subcommand {
   async match(message: Message): Promise<Message> {
     //makes sure future matches are valid (made for the current group / still has matches left)
     const matches = await getMatch();
+    if (!matches.length)
+      return message.reply(`Not enough members with coffee chat role to generate matches.`);
     await alertMatches(matches);
     await writeHistoricMatches(matches);
     return message.reply(`Sent ${matches.length} match(es).`);

--- a/src/components/coffeeChat.ts
+++ b/src/components/coffeeChat.ts
@@ -26,6 +26,7 @@ interface historic_match {
 export const getMatch = async (): Promise<string[][]> => {
   // Gets the list of users that are currently "enrolled" in role
   const userList = await loadRoleUsers(COFFEE_ROLE_ID);
+  if (userList.length <= 1) return [];
 
   // Assigns each user ID a unique index
   const notMatched: Map<string, number> = new Map();

--- a/src/components/cron.ts
+++ b/src/components/cron.ts
@@ -122,16 +122,19 @@ export const createBonusInterviewerListCron = (): CronJob =>
 export const createCoffeeChatCron = (client: Client): CronJob =>
   new CronJob('0 0 14 * * 5', async function () {
     const matches = await getMatch();
-    await alertMatches(matches);
-    await writeHistoricMatches(matches);
 
-    const messageChannel = client.channels.cache.get(NOTIF_CHANNEL_ID);
-    if (!messageChannel) {
-      throw 'Bad channel ID';
-    } else if (messageChannel.type === ChannelType.GuildText) {
-      (messageChannel as TextChannel).send(`Sent ${matches.length} match(es).`);
-    } else {
-      throw 'Bad channel type';
+    if (!matches.length) throw `Not enough members with coffee chat role to generate matches.`;
+    else {
+      await alertMatches(matches);
+      await writeHistoricMatches(matches);
+      const messageChannel = client.channels.cache.get(NOTIF_CHANNEL_ID);
+      if (!messageChannel) {
+        throw 'Bad channel ID';
+      } else if (messageChannel.type === ChannelType.GuildText) {
+        (messageChannel as TextChannel).send(`Sent ${matches.length} match(es).`);
+      } else {
+        throw 'Bad channel type';
+      }
     }
   });
 


### PR DESCRIPTION
## Summary of Changes
Unable to reproduce bug as described in #417 - added code that prevents a user from being matched with themself in the edge case of only one user having the role.

## Related Issues
Resolves #417 

## Steps to Reproduce
Run `.coffee match` with only one user holding the coffeechat role.

## Further Information and Comments
`.coffeechat match` was not working so I removed the `.coffeechat` examples in the command description.
