### PR TITLE
Allow bot to ban users outside server

### DIFF
--- a/src/commandDetails/admin/ban.ts
+++ b/src/commandDetails/admin/ban.ts
@@ -1,6 +1,6 @@
 import { CodeyUserError } from './../../codeyUserError';
 import { container } from '@sapphire/framework';
-import { PermissionsBitField, User } from 'discord.js';
+import { PermissionsBitField, User, GuildMemberManager } from 'discord.js';
 import {
   CodeyCommandDetails,
   CodeyCommandOptionType,
@@ -31,11 +31,9 @@ const banExecuteCommand: SapphireMessageExecuteType = async (client, messageFrom
       );
     }
     const days = <number>args['days'];
-    // Get the GuildMember object corresponding to the user in the guild
-    // This is needed because we can only ban GuildMembers, not Users
+    // get Guild object corresponding to server
     const guild = await client.guilds.fetch(vars.TARGET_GUILD_ID);
-    const memberInGuild = await guild.members.fetch({ user });
-    if (await banUser(memberInGuild, reason, days)) {
+    if (await banUser(guild, user, reason, days)) {
       return `Successfully banned user ${user.tag} (id: ${user.id}) ${
         days ? `and deleted their messages in the past ${days} days ` : ``
       }for the following reason: ${reason}`;

--- a/src/commandDetails/admin/ban.ts
+++ b/src/commandDetails/admin/ban.ts
@@ -8,6 +8,7 @@ import {
 } from '../../codeyCommand';
 import { banUser } from '../../components/admin';
 import { vars } from '../../config';
+import { pluralize } from '../../utils/pluralize';
 
 // Ban a user
 const banExecuteCommand: SapphireMessageExecuteType = async (client, messageFromUser, args) => {
@@ -35,7 +36,7 @@ const banExecuteCommand: SapphireMessageExecuteType = async (client, messageFrom
     const guild = await client.guilds.fetch(vars.TARGET_GUILD_ID);
     if (await banUser(guild, user, reason, days)) {
       return `Successfully banned user ${user.tag} (id: ${user.id}) ${
-        days ? `and deleted their messages in the past ${days} days ` : ``
+        days ? `and deleted their messages in the past ${days} ${pluralize('day', days)} ` : ``
       }for the following reason: ${reason}`;
     } else {
       throw new CodeyUserError(

--- a/src/commandDetails/admin/ban.ts
+++ b/src/commandDetails/admin/ban.ts
@@ -1,6 +1,6 @@
 import { CodeyUserError } from './../../codeyUserError';
 import { container } from '@sapphire/framework';
-import { PermissionsBitField, User, GuildMemberManager } from 'discord.js';
+import { PermissionsBitField, User } from 'discord.js';
 import {
   CodeyCommandDetails,
   CodeyCommandOptionType,

--- a/src/components/admin.ts
+++ b/src/components/admin.ts
@@ -9,7 +9,7 @@ const MOD_USER_ID_FOR_BAN_APPEAL: string = vars.MOD_USER_ID_FOR_BAN_APPEAL;
 const makeBanMessage = (reason: string, days?: number): string =>
   `
 Uh oh, you have been banned from the UW Computer Science Club server ${
-    days && `and your messages in the past ${days} ${pluralize('day', days)} have been deleted `
+    days ? `and your messages in the past ${days} ${pluralize('day', days)} have been deleted `: ''
   }for the following reason:
 
 > ${reason}

--- a/src/components/admin.ts
+++ b/src/components/admin.ts
@@ -9,7 +9,7 @@ const MOD_USER_ID_FOR_BAN_APPEAL: string = vars.MOD_USER_ID_FOR_BAN_APPEAL;
 const makeBanMessage = (reason: string, days?: number): string =>
   `
 Uh oh, you have been banned from the UW Computer Science Club server ${
-    days ? `and your messages in the past ${days} ${pluralize('day', days)} have been deleted `: ''
+    days ? `and your messages in the past ${days} ${pluralize('day', days)} have been deleted ` : ''
   }for the following reason:
 
 > ${reason}

--- a/src/components/admin.ts
+++ b/src/components/admin.ts
@@ -31,13 +31,16 @@ export const banUser = async (
   try {
     try {
       await user.send(makeBanMessage(reason, days));
-    } catch(err){
+    } catch (err) {
       logger.error({
-      event: "Can't send message to user not in server",
-      error: (err as Error).toString(),
+        event: "Can't send message to user not in server",
+        error: (err as Error).toString(),
       });
     }
-    await guild.members.ban(user, {reason: reason, deleteMessageSeconds: (days==null? 0: days * 86400)});
+    await guild.members.ban(user, {
+      reason: reason,
+      deleteMessageSeconds: days == null ? 0 : days * 86400,
+    });
     isSuccessful = true;
   } catch (err) {
     logger.error({

--- a/src/components/admin.ts
+++ b/src/components/admin.ts
@@ -1,4 +1,4 @@
-import { GuildMember } from 'discord.js';
+import { Guild, User } from 'discord.js';
 import { vars } from '../config';
 import { logger } from '../logger/default';
 import { pluralize } from '../utils/pluralize';
@@ -9,7 +9,7 @@ const MOD_USER_ID_FOR_BAN_APPEAL: string = vars.MOD_USER_ID_FOR_BAN_APPEAL;
 const makeBanMessage = (reason: string, days?: number): string =>
   `
 Uh oh, you have been banned from the UW Computer Science Club server ${
-    days && `and your messages in the past ${days} ${pluralize('day', days)} have been deleted`
+    days && `and your messages in the past ${days} ${pluralize('day', days)} have been deleted `
   }for the following reason:
 
 > ${reason}
@@ -19,16 +19,25 @@ a reason why you think you should be unbanned.
 `;
 
 /* Ban a user, returns whether ban was successful */
+// Bans user from guild even if they are not in server
+// makeBanMessage is only sent to User if they are in server (in Discord, you cannot send direct messages to users who are not in any mutual servers)
 export const banUser = async (
-  member: GuildMember,
+  guild: Guild,
+  user: User,
   reason: string,
   days?: number,
 ): Promise<boolean> => {
   let isSuccessful = false;
   try {
-    const user = member.user;
-    await user.send(makeBanMessage(reason, days));
-    await member.ban({ reason, deleteMessageDays: days });
+    try {
+      await user.send(makeBanMessage(reason, days));
+    } catch(err){
+      logger.error({
+      event: "Can't send message to user not in server",
+      error: (err as Error).toString(),
+      });
+    }
+    await guild.members.ban(user, {reason: reason, deleteMessageSeconds: (days==null? 0: days * 86400)});
     isSuccessful = true;
   } catch (err) {
     logger.error({


### PR DESCRIPTION
## Summary of Changes
Allows bot to ban users outside of server even if they have never joined server, previously bot could only ban users already in server.

Note: Ban Message is only sent to banned user if they are already in the server because on Discord direct messages can only be sent to users who are in mutual servers.
