### PR TITLE
Explain the membership process when no UW ID is passed in .member

### DIFF
--- a/src/commandDetails/miscellaneous/member.ts
+++ b/src/commandDetails/miscellaneous/member.ts
@@ -26,18 +26,22 @@ const getMemberEmbed = async (uwid: UwIdType): Promise<EmbedBuilder> => {
   const title = 'CSC Membership Information';
   const EXPLAIN_MEMBERSHIP = `Oops! You didn't provide a UW ID.
 
-  If you're already a CSC member, please provide a UW ID.
+  Please provide a UW ID to check if you are a CSC member.
 
-  If not, perhaps you're interested in becoming one?
+  If you are not, are you interested in being one?
 
   Being a CSC member comes with gaining access to CSC machines, cloud, email, web hosting, and more! Additional details can be found here! https://csclub.uwaterloo.ca/resources/services/
     
   To sign up, you can follow the instructions here! https://csclub.uwaterloo.ca/get-involved/`;
+  const IS_MEMBER_DESCRIPTION = `You're a CSC member! Hooray! ${getEmojiByName('codey_love')}`;
+  const NOT_MEMBER_DESCRIPTION = `You're not a CSC member! ${getEmojiByName('codey_sad')}
+
+  Being a CSC member comes with gaining access to CSC machines, cloud, email, web hosting, and more! Additional details can be found here! https://csclub.uwaterloo.ca/resources/services/
+
+  To sign up, you can follow the instructions here! https://csclub.uwaterloo.ca/get-involved/`;
+
   if (!uwid) {
-    return new EmbedBuilder()
-      .setColor('Red')
-      .setTitle(title)
-      .setDescription(EXPLAIN_MEMBERSHIP);
+    return new EmbedBuilder().setColor('Blue').setTitle(title).setDescription(EXPLAIN_MEMBERSHIP);
   }
 
   const members = (await (await fetch(MEMBER_API)).json()).members as memberStatus[];
@@ -47,14 +51,9 @@ const getMemberEmbed = async (uwid: UwIdType): Promise<EmbedBuilder> => {
     return new EmbedBuilder()
       .setColor('Green')
       .setTitle(title)
-      .setDescription(`You're a CSC member! Hooray! ${getEmojiByName('codey_love')}`);
+      .setDescription(IS_MEMBER_DESCRIPTION);
   }
 
-  const NOT_MEMBER_DESCRIPTION = `You're not a CSC member! ${getEmojiByName('codey_sad')}
-
-Being a CSC member comes with gaining access to CSC machines, cloud, email, web hosting, and more! Additional details can be found here! https://csclub.uwaterloo.ca/resources/services/
-
-To sign up, you can follow the instructions here! https://csclub.uwaterloo.ca/get-involved/`;
   return new EmbedBuilder().setColor('Red').setTitle(title).setDescription(NOT_MEMBER_DESCRIPTION);
 };
 

--- a/src/commandDetails/miscellaneous/member.ts
+++ b/src/commandDetails/miscellaneous/member.ts
@@ -24,11 +24,20 @@ type UwIdType = string | undefined;
  */
 const getMemberEmbed = async (uwid: UwIdType): Promise<EmbedBuilder> => {
   const title = 'CSC Membership Information';
+  const EXPLAIN_MEMBERSHIP = `Oops! You didn't provide a UW ID.
+
+  If you're already a CSC member, please provide a UW ID.
+
+  If not, perhaps you're interested in becoming one?
+
+  Being a CSC member comes with gaining access to CSC machines, cloud, email, web hosting, and more! Additional details can be found here! https://csclub.uwaterloo.ca/resources/services/
+    
+  To sign up, you can follow the instructions here! https://csclub.uwaterloo.ca/get-involved/`;
   if (!uwid) {
     return new EmbedBuilder()
       .setColor('Red')
       .setTitle(title)
-      .setDescription('Please provide a UW ID!');
+      .setDescription(EXPLAIN_MEMBERSHIP);
   }
 
   const members = (await (await fetch(MEMBER_API)).json()).members as memberStatus[];
@@ -82,7 +91,7 @@ export const memberCommandDetails: CodeyCommandDetails = {
       name: 'uwid',
       description: 'The Quest ID of the user.',
       type: CodeyCommandOptionType.STRING,
-      required: true,
+      required: false,
     },
   ],
   subcommandDetails: {},


### PR DESCRIPTION
## Summary of Changes
- Made the uwid field optional instead of required
- An embed with membership info will show up if no uwid is passed in

## Resolved Requests
- Resolved request #498 

## Notes
I'd say my membership explanation isn't exactly the most appealing one, so I'm open to any suggestions to make it more appealing.
