### PR TITLE
Send receiver a dm on CodeyCoin transfer to notify them

### DIFF
--- a/src/commandDetails/coin/transfer.ts
+++ b/src/commandDetails/coin/transfer.ts
@@ -1,5 +1,5 @@
 import { SapphireClient, container } from '@sapphire/framework';
-import { CommandInteraction, Embed, EmbedBuilder, Message, User, userMention } from 'discord.js';
+import { EmbedBuilder, Message, User, userMention } from 'discord.js';
 import {
   CodeyCommandOptionType,
   CodeyCommandDetails,
@@ -10,7 +10,6 @@ import {
 } from '../../codeyCommand';
 import { getCoinBalanceByUserId, transferTracker } from '../../components/coin';
 import { getCoinEmoji } from '../../components/emojis';
-import { receiveMessageOnPort } from 'worker_threads';
 
 const coinTransferExecuteCommand: SapphireMessageExecuteType = async (
   client,

--- a/src/components/coin.ts
+++ b/src/components/coin.ts
@@ -443,19 +443,15 @@ export class Transfer {
       case TransferResult.Confirmed:
         const newReceiverBalance = await getCoinBalanceByUserId(this.state.receiver.id);
         const newSenderBalance = await getCoinBalanceByUserId(this.state.sender.id);
-        return `${this.state.receiver.username} accepted the transfer. ${
-          this.state.receiver.username
-        } now has ${newReceiverBalance} Codey ${pluralize(
+        return `${this.state.receiver.toString()} accepted the transfer. ${this.state.receiver.toString()} now has ${newReceiverBalance} Codey ${pluralize(
           'coin',
           newReceiverBalance,
-        )} ${getCoinEmoji()}. ${
-          this.state.sender.username
-        } now has ${newSenderBalance} Codey ${pluralize(
+        )} ${getCoinEmoji()}. ${this.state.sender.toString()} now has ${newSenderBalance} Codey ${pluralize(
           'coin',
           newSenderBalance,
         )} ${getCoinEmoji()}.`;
       case TransferResult.Rejected:
-        return `This transfer was rejected by ${this.state.receiver.username}.`;
+        return `This transfer was rejected by ${this.state.receiver.toString()}.`;
       case TransferResult.Pending:
         return 'Please choose whether you would like to accept this transfer.';
       case TransferResult.Invalid:


### PR DESCRIPTION
## Summary of Changes
Upon transfers being initiated, send the receiving user a DM with a link to the transfer in order to notify them.

Also edits the transfer embed status message upon transfer completion to display user mentions instead of username

## Motivation and Explanation
We previously added a timeout to transfers, so without the receiving user being aware of the transfer beforehand it is difficult to react and accept it within the timeout.

## Related Issues
resolves #506 

## Steps to Reproduce
Coordinate with a second person to test transfers, or comment out the code that prevents sending transfers to oneself.

## Demonstration of Changes
![image](https://github.com/uwcsc/codeybot/assets/69977136/f30c33fb-0937-4e36-9a78-c74bc224a65a)
![image](https://github.com/uwcsc/codeybot/assets/69977136/cc493f8b-c863-4f95-a4cb-40f7d50848ee)

## Further Information and Comments
Apologies for the delay in getting this fixed
