### PR TITLE
Issue# 471

### DIFF
--- a/src/commandDetails/coin/leaderboard.ts
+++ b/src/commandDetails/coin/leaderboard.ts
@@ -70,6 +70,7 @@ const getCoinLeaderboardEmbed = async (
         .join('\\_')
         .split('`')
         .join('\\`');
+      // added a "\\" below in ${rank}\\. ${cleanUserTag} so that Markdown does not automatically increment by 1 each time
       const userCoinEntryText = `${rank}\\. ${cleanUserTag} - ${
         userCoinEntry.balance
       } ${getCoinEmoji()}`;

--- a/src/commandDetails/coin/leaderboard.ts
+++ b/src/commandDetails/coin/leaderboard.ts
@@ -70,33 +70,23 @@ const getCoinLeaderboardEmbed = async (
         .join('\\_')
         .split('`')
         .join('\\`');
-        console.log("RANK:", rank);
-        console.log("Position:", position);
-        console.log("Previous Balance:", previousBalance);
-        console.log("offset:", offset);
-        console.log("User Coin Entry Balance:", userCoinEntry.balance);
       const userCoinEntryText = `${rank}\\. ${cleanUserTag} - ${
         userCoinEntry.balance
       } ${getCoinEmoji()}`;
-      console.log("userCoinEntry is: ", userCoinEntryText);
       leaderboardArray.push(userCoinEntryText);
     }
   }
   const leaderboardText = leaderboardArray.join('\n');
-  console.log("leaderboardtext is: ", leaderboardText);
   const leaderboardEmbed = new EmbedBuilder()
     .setColor(DEFAULT_EMBED_COLOUR)
     .setTitle('Codey Coin Leaderboard')
     .setDescription(leaderboardText);
-
-    console.log("leaderboard embed is: ", leaderboardEmbed);
   leaderboardEmbed.addFields([
     {
       name: 'Your Position',
       value: `You are currently **#${position}** in the leaderboard with ${userBalance} ${getCoinEmoji()}.`,
     },
   ]);
-  console.log("leaderboard embed is: ", leaderboardEmbed);
   return leaderboardEmbed;
 };
 

--- a/src/commandDetails/coin/leaderboard.ts
+++ b/src/commandDetails/coin/leaderboard.ts
@@ -29,6 +29,7 @@ const getCoinLeaderboardEmbed = async (
   let rank = 0;
   let offset = 0;
   let i = 0;
+  let absoluteCount = 0;
   while (leaderboardArray.length < LEADERBOARD_LIMIT_DISPLAY || position === 0) {
     if (i === LEADERBOARD_LIMIT_FETCH) {
       offset += LEADERBOARD_LIMIT_FETCH;
@@ -46,10 +47,15 @@ const getCoinLeaderboardEmbed = async (
       continue;
     }
     if (user.bot) continue;
-    if (previousBalance !== userCoinEntry.balance) {
+    if (previousBalance === userCoinEntry.balance) {
       previousBalance = userCoinEntry.balance;
-      rank = rank + 1;
+      // rank does not change
+    } else {
+      previousBalance = userCoinEntry.balance;
+      rank = absoluteCount + 1;
     }
+    // count how many total users have been processed:
+    absoluteCount++;
     if (userCoinEntry.user_id === userId) {
       position = rank;
     }
@@ -64,24 +70,33 @@ const getCoinLeaderboardEmbed = async (
         .join('\\_')
         .split('`')
         .join('\\`');
-      const userCoinEntryText = `${rank}. ${cleanUserTag} - ${
+        console.log("RANK:", rank);
+        console.log("Position:", position);
+        console.log("Previous Balance:", previousBalance);
+        console.log("offset:", offset);
+        console.log("User Coin Entry Balance:", userCoinEntry.balance);
+      const userCoinEntryText = `${rank}\\. ${cleanUserTag} - ${
         userCoinEntry.balance
       } ${getCoinEmoji()}`;
+      console.log("userCoinEntry is: ", userCoinEntryText);
       leaderboardArray.push(userCoinEntryText);
     }
   }
   const leaderboardText = leaderboardArray.join('\n');
+  console.log("leaderboardtext is: ", leaderboardText);
   const leaderboardEmbed = new EmbedBuilder()
     .setColor(DEFAULT_EMBED_COLOUR)
     .setTitle('Codey Coin Leaderboard')
     .setDescription(leaderboardText);
+
+    console.log("leaderboard embed is: ", leaderboardEmbed);
   leaderboardEmbed.addFields([
     {
       name: 'Your Position',
       value: `You are currently **#${position}** in the leaderboard with ${userBalance} ${getCoinEmoji()}.`,
     },
   ]);
-
+  console.log("leaderboard embed is: ", leaderboardEmbed);
   return leaderboardEmbed;
 };
 


### PR DESCRIPTION
## Summary of Changes
Changed CodeyCoin leaderboard to allow for tie handling (i.e. users with same number of CodeyCoins are ranked the same number on the leaderboard).

- A counter called absoluteCounter was introduced to keep track of the number of users iterated through on the leaderboard, to update the rank accordingly.


## Motivation and Explanation
Previously to this commit, ties in CodeyCoin balances would result in misleading output in the leaderboard. For example, multiple users with the same balance would not be ranked the same position:
![image](https://github.com/uwcsc/codeybot/assets/111328484/6bde114a-03ba-4440-bc0c-9f97a8382852)



## Demonstration of Changes
![image](https://github.com/uwcsc/codeybot/assets/111328484/88899d11-d405-4191-bb89-16a033e9caa8)

## Further Information and Comments
This PR fixes issue [471](https://github.com/uwcsc/codeybot/issues/471)
