### PR TITLE
Fix leaderboard error

### DIFF
--- a/src/commandDetails/coin/leaderboard.ts
+++ b/src/commandDetails/coin/leaderboard.ts
@@ -36,7 +36,7 @@ const getCoinLeaderboardEmbed = async (
       leaderboard = await getCoinLeaderboard(LEADERBOARD_LIMIT_FETCH, offset);
       i = 0;
     }
-    if (leaderboard.length === 0) {
+    if (i >= leaderboard.length) {
       break;
     }
     const userCoinEntry = leaderboard[i++];


### PR DESCRIPTION
The latest leaderboard change accidentally removed suppression of an error that should not be happening. Instead of breaking when the fetched array is empty, we now stop as soon as our iterator goes beyond the end of the array. This will only happen if not enough entries were fetched to fill the fetch limit, meaning we've run out of entries.

This does not affect prod as there are enough users to avoid this, but this error breaks development (and obviously should be fixed anyway).