### PR TITLE
Patch infinite money glitch by mutexing coin transfers and blackjack

### DIFF
--- a/src/commandDetails/coin/transfer.ts
+++ b/src/commandDetails/coin/transfer.ts
@@ -1,15 +1,16 @@
 import { SapphireClient, container } from '@sapphire/framework';
 import { CommandInteraction, EmbedBuilder, Message, User, userMention } from 'discord.js';
 import {
-  CodeyCommandOptionType,
   CodeyCommandDetails,
-  SapphireMessageExecuteType,
-  getUserFromMessage,
-  SapphireMessageResponseWithMetadata,
+  CodeyCommandOptionType,
   SapphireAfterReplyType,
+  SapphireMessageExecuteType,
+  SapphireMessageResponseWithMetadata,
+  getUserFromMessage,
 } from '../../codeyCommand';
 import { getCoinBalanceByUserId, transferTracker } from '../../components/coin';
 import { getCoinEmoji } from '../../components/emojis';
+import { gamesByPlayerId } from '../../components/games/blackjack.js';
 
 const coinTransferExecuteCommand: SapphireMessageExecuteType = async (
   client,
@@ -55,6 +56,20 @@ const coinTransferExecuteCommand: SapphireMessageExecuteType = async (
     );
   } else if (amount < 1) {
     return new SapphireMessageResponseWithMetadata(`You can't transfer less than 1 coin.`, {});
+  }
+
+  if (transferTracker.transferringUsers.has(sendingUser.id)) {
+    return new SapphireMessageResponseWithMetadata(
+      `Please finish your current transfer first.`,
+      {},
+    );
+  }
+
+  if (gamesByPlayerId.has(sendingUser.id)) {
+    return new SapphireMessageResponseWithMetadata(
+      `Please finish your current blackjack game before transferring coins.`,
+      {},
+    );
   }
 
   const transfer = await transferTracker.startTransfer(

--- a/src/commandDetails/games/blackjack.ts
+++ b/src/commandDetails/games/blackjack.ts
@@ -1,30 +1,13 @@
 import { container } from '@sapphire/framework';
 import {
-  Colors,
-  EmbedBuilder,
-  ButtonBuilder,
-  ButtonStyle,
   ActionRowBuilder,
+  ButtonBuilder,
   ButtonInteraction,
+  ButtonStyle,
+  Colors,
   ComponentType,
+  EmbedBuilder,
 } from 'discord.js';
-import {
-  adjustCoinBalanceByUserId,
-  getCoinBalanceByUserId,
-  UserCoinEvent,
-} from '../../components/coin';
-import { getCoinEmoji, getEmojiByName } from '../../components/emojis';
-import {
-  BlackjackAction,
-  BlackjackHand,
-  BlackjackStage,
-  CardSuit,
-  endGame,
-  GameState,
-  performGameAction,
-  startGame,
-} from '../../components/games/blackjack';
-import { pluralize } from '../../utils/pluralize';
 import {
   CodeyCommandDetails,
   CodeyCommandOptionType,
@@ -32,6 +15,25 @@ import {
   SapphireMessageResponse,
   getUserFromMessage,
 } from '../../codeyCommand';
+import {
+  UserCoinEvent,
+  adjustCoinBalanceByUserId,
+  getCoinBalanceByUserId,
+  transferTracker,
+} from '../../components/coin';
+import { getCoinEmoji, getEmojiByName } from '../../components/emojis';
+import {
+  BlackjackAction,
+  BlackjackHand,
+  BlackjackStage,
+  CardSuit,
+  GameState,
+  endGame,
+  gamesByPlayerId,
+  performGameAction,
+  startGame,
+} from '../../components/games/blackjack';
+import { pluralize } from '../../utils/pluralize';
 
 // CodeyCoin constants
 const DEFAULT_BET = 10;
@@ -221,6 +223,14 @@ const blackjackExecuteCommand: SapphireMessageExecuteType = async (
   const playerBalance = await getCoinBalanceByUserId(author);
   if (playerBalance! < bet) {
     return `You don't have enough coins to place that bet. ${getEmojiByName('codey_sad')}`;
+  }
+
+  if (transferTracker.transferringUsers.has(author)) {
+    return `Please finish your current coin transfer before starting a game.`;
+  }
+
+  if (gamesByPlayerId.has(author)) {
+    return `Please finish your current game before starting another one!`;
   }
 
   // Initialize the game

--- a/src/components/games/blackjack.ts
+++ b/src/components/games/blackjack.ts
@@ -38,7 +38,7 @@ export enum CardSuit {
 }
 
 // keeps track of games by player's Discord IDs
-const gamesByPlayerId = new Map<string, BlackjackGame>();
+export const gamesByPlayerId = new Map<string, BlackjackGame>();
 
 // maps action Enum to game action
 const gameActionsMap = new Map<BlackjackAction, () => Action>([


### PR DESCRIPTION
## Summary of Changes
- currently, users can start a blackjack game, transfer their money away, and since balance cannot be negative, they are protected from losses and can get infinite money for free
- this fixes this by preventing transfers and blackjack games from ongoing concurrently

## Related Issues
- #523

## Steps to Reproduce
- attempt to start a blackjack game while a transfer is pending, or attempt to start a transfer while playing blackjack