### PR TITLE
401 add pagination helper

### DIFF
--- a/docs/COMMAND-WIKI.md
+++ b/docs/COMMAND-WIKI.md
@@ -258,6 +258,13 @@
     - ``uwid``: The Quest ID of the user.
 - **Subcommands:** None
 
+## pg
+- **Aliases:** `pagination`, `paginationtest`, `pgtest`
+- **Description:** Test the pagination feature.
+- **Examples:**<br>  `.pg`<br>  `.pagination`<br>  `.pagination`<br>  `.pgtest`
+- **Options:** None
+- **Subcommands:** None
+
 ## ping
 - **Aliases:** `pong`
 - **Description:** Ping the bot to see if it is alive. :ping_pong:

--- a/src/commandDetails/miscellaneous/pagination-test.ts
+++ b/src/commandDetails/miscellaneous/pagination-test.ts
@@ -1,0 +1,67 @@
+import { container, SapphireClient } from '@sapphire/framework';
+import { CodeyCommandDetails, getUserFromMessage } from '../../codeyCommand';
+import { EmbedBuilder, ButtonInteraction, ComponentType } from 'discord.js';
+import { PaginationBuilder } from '../../utils/pagination';
+import { Command as SapphireCommand } from '@sapphire/framework';
+import { SapphireMessageExecuteType, SapphireMessageResponse } from '../../codeyCommand';  
+import {
+    Colors,
+    ButtonBuilder,
+    ButtonStyle,
+    ActionRowBuilder,
+    Message
+  } from 'discord.js';
+const PaginationTestExecuteCommand: SapphireMessageExecuteType = async (
+    _client,
+    messageFromUser,
+    _args,
+  ): Promise<SapphireMessageResponse> => {
+    const message = messageFromUser;
+    const author = getUserFromMessage(message).id;
+    
+    const embedData = [
+      { title: 'Page 1', description: 'Content of Page 1 💙', color: 0xFF0000 },
+      { title: 'Page 2', description: 'Content of Page 2 🎉', color: 0x00FF00 },
+      { title: 'Page 3', description: 'Content of Page 3 👽', color: 0x0000FF }
+    ];
+
+    const embeds = embedData.map(data =>
+      new EmbedBuilder()
+        .setColor(Colors.Blue)
+        .setTitle(data.title)
+        .setDescription(data.description)
+        .setColor(data.color)
+    );
+    const msg = await message.reply({
+        embeds: [embeds[0]],
+        fetchReply: true
+      });  
+    
+    const reactFilter = (reaction: ButtonInteraction) => {
+        return reaction.user.id === author;
+    };
+
+    try {
+      await PaginationBuilder(msg, reactFilter, embeds);
+    } catch (error) {
+      await message.reply('Error or timeout occurred during navigation.');
+    }
+};
+
+export const paginationTestCommandDetails: CodeyCommandDetails = {
+  name: 'pg',
+  aliases: ['pagination', 'paginationtest', 'pgtest'],
+  description: 'Test the pagination feature.',
+  detailedDescription: `**Examples:**
+  \`${container.botPrefix}pg\`
+  \`${container.botPrefix}pagination\`
+  \`${container.botPrefix}pagination\`
+  \`${container.botPrefix}pgtest\``,
+
+  isCommandResponseEphemeral: false,
+  messageWhenExecutingCommand: 'Testing pagination...',
+  executeCommand: PaginationTestExecuteCommand,
+  messageIfFailure: 'Could not test pagination.',
+  options: [],
+  subcommandDetails: {},
+};

--- a/src/commandDetails/miscellaneous/pagination-test.ts
+++ b/src/commandDetails/miscellaneous/pagination-test.ts
@@ -2,50 +2,67 @@ import { container, SapphireClient } from '@sapphire/framework';
 import { CodeyCommandDetails, getUserFromMessage } from '../../codeyCommand';
 import { EmbedBuilder, ButtonInteraction, ComponentType } from 'discord.js';
 import { PaginationBuilder } from '../../utils/pagination';
-import { Command as SapphireCommand } from '@sapphire/framework';
 import { SapphireMessageExecuteType, SapphireMessageResponse } from '../../codeyCommand';  
-import {
-    Colors,
-    ButtonBuilder,
-    ButtonStyle,
-    ActionRowBuilder,
-    Message
-  } from 'discord.js';
+import { Colors } from 'discord.js';
+
 const PaginationTestExecuteCommand: SapphireMessageExecuteType = async (
-    _client,
-    messageFromUser,
-    _args,
-  ): Promise<SapphireMessageResponse> => {
-    const message = messageFromUser;
-    const author = getUserFromMessage(message).id;
+  _client,
+  messageFromUser,
+  _args,
+): Promise<SapphireMessageResponse> => {
+  const message = messageFromUser;
+  const author = getUserFromMessage(message).id;
     
-    const embedData = [
-      { title: 'Page 1', description: 'Content of Page 1 💙', color: 0xFF0000 },
-      { title: 'Page 2', description: 'Content of Page 2 🎉', color: 0x00FF00 },
-      { title: 'Page 3', description: 'Content of Page 3 👽', color: 0x0000FF }
-    ];
+  const embedData: { title: string; description: string; color: number }[] = [
+    {
+      title: 'Page 1', 
+      description: 'Hey there! This is the content of Page 1 💙', 
+      color: 0xFF0000 
+    },
+    {
+      title: 'Page 2', 
+      description: 'Hey there! This is the content of Page 2 🎉', 
+      color: 0x00FF00 
+    },
+    {
+      title: 'Page 3', 
+      description: 'Hey there! This is the content of Page 3 👽', 
+      color: 0x0000FF 
+    },
+    {
+      title: 'Page 4', 
+      description: 'Hey there! This is the content of Page 4 🎃', 
+      color: 0xFF00FF 
+    },
+    {
+      title: 'Page 5', 
+      description: 'Hey there! This is the content of Page 5 🎄', 
+      color: 0xFFFF00 
+    },
+  ];
 
-    const embeds = embedData.map(data =>
-      new EmbedBuilder()
-        .setColor(Colors.Blue)
-        .setTitle(data.title)
-        .setDescription(data.description)
-        .setColor(data.color)
-    );
-    const msg = await message.reply({
-        embeds: [embeds[0]],
-        fetchReply: true
-      });  
+  const embeds: EmbedBuilder[] = embedData.map((data) =>
+    new EmbedBuilder()
+      .setColor(Colors.Blue)
+      .setTitle(data.title)
+      .setDescription(data.description)
+      .setColor(data.color)
+  );
+  
+  const msg = await message.reply({
+    embeds: (embeds.length > 0) ? [embeds[0]] : [new EmbedBuilder().setColor(Colors.Red).setDescription('No pages to display.')],
+    fetchReply: true
+  });  
     
-    const reactFilter = (reaction: ButtonInteraction) => {
-        return reaction.user.id === author;
-    };
+  const reactFilter = (reaction: ButtonInteraction) => {
+    return reaction.user.id === author;
+  };
 
-    try {
-      await PaginationBuilder(msg, reactFilter, embeds);
-    } catch (error) {
-      await message.reply('Error or timeout occurred during navigation.');
-    }
+  try {
+    await PaginationBuilder(msg, reactFilter, embeds);
+  } catch (error) {
+    await message.reply('Error or timeout occurred during navigation.');
+  }
 };
 
 export const paginationTestCommandDetails: CodeyCommandDetails = {

--- a/src/commands/miscellaneous/pagination-test.ts
+++ b/src/commands/miscellaneous/pagination-test.ts
@@ -1,0 +1,16 @@
+import { Command } from '@sapphire/framework';
+import { CodeyCommand } from '../../codeyCommand';
+import { paginationTestCommandDetails } from '../../commandDetails/miscellaneous/pagination-test';
+
+export class MiscellaneousPaginationTestCommand extends CodeyCommand {
+  details = paginationTestCommandDetails;
+
+  public constructor(context: Command.Context, options: Command.Options) {
+    super(context, {
+      ...options,
+      aliases: paginationTestCommandDetails.aliases,
+      description: paginationTestCommandDetails.description,
+      detailedDescription: paginationTestCommandDetails.detailedDescription,
+    });
+  }
+}

--- a/src/utils/pagination.ts
+++ b/src/utils/pagination.ts
@@ -1,0 +1,113 @@
+import {
+  Colors,
+  EmbedBuilder,
+  ButtonBuilder,
+  ButtonStyle,
+  ActionRowBuilder,
+  ButtonInteraction,
+  ComponentType,
+  Message
+} from 'discord.js';
+  
+const COLLECTOR_TIMEOUT = 60000;
+  
+export const PaginationBuilder = async (
+  message: Message,
+  reactFilter: (reaction: ButtonInteraction) => boolean,
+  embedPages: EmbedBuilder[],
+): Promise<Message<boolean> | undefined> => {
+  try {
+    if (!message || !embedPages || !embedPages.length) return;
+      
+    var currentPage = 0;
+    const firstButton = new ButtonBuilder()
+      .setCustomId('first')
+      .setEmoji('⏮️')
+      .setLabel('First')
+      .setStyle(ButtonStyle.Primary)
+      .setDisabled(true);
+    const previousButton = new ButtonBuilder()
+      .setCustomId('previous')
+      .setEmoji('⬅️')
+      .setLabel('Previous')
+      .setStyle(ButtonStyle.Primary)
+      .setDisabled(true);
+    const pageCount = new ButtonBuilder()
+      .setCustomId('pagecount')
+      .setLabel(`${currentPage + 1}/${embedPages.length}`)
+      .setStyle(ButtonStyle.Secondary)
+      .setDisabled(true);
+    const nextButton = new ButtonBuilder()
+      .setCustomId('next')
+      .setEmoji('➡️')
+      .setLabel('Next')
+      .setStyle(ButtonStyle.Primary);
+    const lastButton = new ButtonBuilder()
+      .setCustomId('last')
+      .setEmoji('⏭️')
+      .setLabel('Last')
+      .setStyle(ButtonStyle.Primary);
+    const actionRow = new ActionRowBuilder<ButtonBuilder>().addComponents(
+      firstButton,
+      previousButton,
+      pageCount,
+      nextButton,
+      lastButton,
+    );
+
+    await message.edit({
+      embeds: [embedPages[currentPage]],
+      components: [actionRow],
+    });
+
+    const collector = message.createMessageComponentCollector({
+      filter: reactFilter,
+      componentType: ComponentType.Button,
+      time: COLLECTOR_TIMEOUT,
+    });
+
+    collector.on('collect', async (buttonInteraction: ButtonInteraction) => {
+      await buttonInteraction.deferUpdate();
+
+      switch (buttonInteraction.customId) {
+        case 'first':
+          currentPage = 0;
+          break;
+        case 'previous':
+          currentPage = Math.max(0, currentPage - 1);
+          break;
+        case 'next':
+          currentPage = Math.min(embedPages.length - 1, currentPage + 1);
+          break;
+        case 'last':
+          currentPage = embedPages.length - 1;
+          break;
+      }
+
+      // Update button states based on the current page
+      firstButton.setDisabled(currentPage === 0);
+      previousButton.setDisabled(currentPage === 0);
+      nextButton.setDisabled(currentPage === embedPages.length - 1);
+      lastButton.setDisabled(currentPage === embedPages.length - 1);
+      pageCount.setLabel(`${currentPage + 1}/${embedPages.length}`);
+
+      // Update the message with the new embed and button states
+      await message.edit({
+        embeds: [embedPages[currentPage]],
+        components: [actionRow],
+      });
+    });
+
+    collector.on('end', async () => {
+      await message.edit({
+        components: []
+      });
+    });
+
+    return message;
+  } catch (error) {
+    console.error('An error occurred:', error);
+    return undefined;
+  }
+};
+  

--- a/src/utils/pagination.ts
+++ b/src/utils/pagination.ts
@@ -1,5 +1,4 @@
 import {
-  Colors,
   EmbedBuilder,
   ButtonBuilder,
   ButtonStyle,
@@ -23,13 +22,13 @@ export const PaginationBuilder = async (
     const firstButton = new ButtonBuilder()
       .setCustomId('first')
       .setEmoji('⏮️')
-      .setLabel('First')
+      // .setLabel('First')
       .setStyle(ButtonStyle.Primary)
       .setDisabled(true);
     const previousButton = new ButtonBuilder()
       .setCustomId('previous')
       .setEmoji('⬅️')
-      .setLabel('Previous')
+      // .setLabel('Previous')
       .setStyle(ButtonStyle.Primary)
       .setDisabled(true);
     const pageCount = new ButtonBuilder()
@@ -40,13 +39,15 @@ export const PaginationBuilder = async (
     const nextButton = new ButtonBuilder()
       .setCustomId('next')
       .setEmoji('➡️')
-      .setLabel('Next')
-      .setStyle(ButtonStyle.Primary);
+      // .setLabel('Next')
+      .setStyle(ButtonStyle.Primary)
+      .setDisabled(embedPages.length <= 1);
     const lastButton = new ButtonBuilder()
       .setCustomId('last')
       .setEmoji('⏭️')
-      .setLabel('Last')
-      .setStyle(ButtonStyle.Primary);
+      // .setLabel('Last')
+      .setStyle(ButtonStyle.Primary)
+      .setDisabled(embedPages.length <= 1);
     const actionRow = new ActionRowBuilder<ButtonBuilder>().addComponents(
       firstButton,
       previousButton,
@@ -84,14 +85,12 @@ export const PaginationBuilder = async (
           break;
       }
 
-      // Update button states based on the current page
       firstButton.setDisabled(currentPage === 0);
       previousButton.setDisabled(currentPage === 0);
       nextButton.setDisabled(currentPage === embedPages.length - 1);
       lastButton.setDisabled(currentPage === embedPages.length - 1);
       pageCount.setLabel(`${currentPage + 1}/${embedPages.length}`);
 
-      // Update the message with the new embed and button states
       await message.edit({
         embeds: [embedPages[currentPage]],
         components: [actionRow],


### PR DESCRIPTION
## Summary of Changes
* This ticket addresses the implementation for an efficient pagination helper function.

## Motivation and Explanation
* This feature improve the bot as it expands functionality, such as displaying long paragraphs of text in a paginated way 

## Related Issues
* Resolves #401

## Steps to Reproduce
* Run the discord bot and checkout to branch 401-add-pagination-helper
* Call `.pg`, `.pagination`, or `.pgtest` in your test channel to try out an example pagination I wrote

## Demonstration of Changes
* A sample demo for using pagination is provided through `src/commands/miscellaneous/pagination-test.ts` and `src/commandDetails/miscellaneous/pagination-test.ts`, which can be removed.

## Further Information and Comments
* Let me know if there's any changes I can make or improvements in my code style, documentation, etc.! 
