### PR TITLE
improve ban command input

### DIFF
--- a/src/components/admin.ts
+++ b/src/components/admin.ts
@@ -1,15 +1,20 @@
 import { Guild, User } from 'discord.js';
 import { vars } from '../config';
 import { logger } from '../logger/default';
-import { pluralize } from '../utils/pluralize';
+import { DurationStyle, formatDuration } from '../utils/formatDuration.js';
 
 const MOD_USER_ID_FOR_BAN_APPEAL: string = vars.MOD_USER_ID_FOR_BAN_APPEAL;
 
 /* Make ban message */
-const makeBanMessage = (reason: string, days?: number): string =>
+const makeBanMessage = (reason: string, duration?: number): string =>
   `
 Uh oh, you have been banned from the UW Computer Science Club server ${
-    days ? `and your messages in the past ${days} ${pluralize('day', days)} have been deleted ` : ''
+    duration
+      ? `and your messages in the past ${formatDuration(
+          duration,
+          DurationStyle.Blank,
+        )} have been deleted `
+      : ''
   }for the following reason:
 
 > ${reason}
@@ -25,12 +30,12 @@ export const banUser = async (
   guild: Guild,
   user: User,
   reason: string,
-  days?: number,
+  duration?: number,
 ): Promise<boolean> => {
   let isSuccessful = false;
   try {
     try {
-      await user.send(makeBanMessage(reason, days));
+      await user.send(makeBanMessage(reason, duration));
     } catch (err) {
       logger.error({
         event: "Can't send message to user not in server",
@@ -39,7 +44,7 @@ export const banUser = async (
     }
     await guild.members.ban(user, {
       reason: reason,
-      deleteMessageSeconds: days == null ? 0 : days * 86400,
+      deleteMessageSeconds: duration === undefined ? 0 : Math.floor(duration / 1000),
     });
     isSuccessful = true;
   } catch (err) {

--- a/src/utils/formatDuration.ts
+++ b/src/utils/formatDuration.ts
@@ -1,0 +1,61 @@
+/**
+ * Formats a duration in milliseconds into English text.
+ * @param duration - The duration in milliseconds
+ * @param style - The style to format the duration in
+ * @returns The formatted duration
+ */
+export const formatDuration = (duration: number, style = DurationStyle.For): string => {
+  if (duration === Infinity) return 'indefinitely';
+
+  duration = Math.round(duration / 1000);
+
+  if (duration < 0) {
+    const core = _formatDuration(-duration);
+    if (style === DurationStyle.Blank) return `negative ${core}`;
+    if (style === DurationStyle.For) return `for negative ${core}`;
+    if (style === DurationStyle.Until) return `until ${core} ago`;
+  }
+
+  if (duration === 0) {
+    if (style === DurationStyle.Blank) return 'no time';
+    if (style === DurationStyle.For) return 'for no time';
+    if (style === DurationStyle.Until) return 'until right now';
+  }
+
+  const core = _formatDuration(duration);
+  if (style === DurationStyle.Blank) return core;
+  if (style === DurationStyle.For) return `for ${core}`;
+  if (style === DurationStyle.Until) return `until ${core} from now`;
+
+  return '??';
+};
+
+function _formatDuration(duration: number): string {
+  if (duration === Infinity) return 'indefinitely';
+
+  const parts: string[] = [];
+
+  for (const [name, scale] of formatTimescales) {
+    if (duration >= scale) {
+      const amount = Math.floor(duration / scale);
+      duration %= scale;
+
+      parts.push(`${amount} ${name}${amount === 1 ? '' : 's'}`);
+    }
+  }
+
+  return parts.join(' ');
+}
+
+export enum DurationStyle {
+  Blank,
+  For,
+  Until,
+}
+
+const formatTimescales: [string, number][] = [
+  ['day', 86400],
+  ['hour', 3600],
+  ['minute', 60],
+  ['second', 1],
+];

--- a/src/utils/parseDuration.ts
+++ b/src/utils/parseDuration.ts
@@ -1,0 +1,31 @@
+/**
+ * Parses English text into a duration in milliseconds. Works for long for (1 day,
+ * 3 weeks 2 hours) and short form (1d, 3w2h).
+ *
+ * @param text - The text to parse
+ * @returns The duration in milliseconds or null if invalid
+ */
+export const parseDuration = (text: string): number | null => {
+  const match = text.match(
+    /^(\d+\s*w(eeks?)?\s*)?(\d+\s*d(ays?)?\s*)?(\d+\s*h((ou)?rs?)?\s*)?(\d+\s*m(in(ute)?s?)?\s*)?(\d+\s*s(ec(ond)?s?)?\s*)?$/,
+  );
+
+  if (!match) return null;
+
+  let duration = 0;
+
+  for (const [index, scale] of parseTimescales) {
+    const submatch = match[index]?.match(/\d+/);
+    if (submatch) duration += parseInt(submatch[0]) * scale;
+  }
+
+  return duration;
+};
+
+const parseTimescales = [
+  [1, 604800000],
+  [3, 86400000],
+  [5, 3600000],
+  [8, 60000],
+  [11, 1000],
+];


### PR DESCRIPTION
## Summary of Changes
- currently, the ban command only allows inputting a number of days for purging on ban, which is outdated as full second-by-second granularity is now supporter
- additionally, the ban command will currently experience an internal error if the duration provided exceeds the maximum allowance of 7 days instead of offering a descriptive error message
- this change allows inputting any duration and provides a meaningful error message

## Steps to Reproduce
- use the ban command

## Demonstration of Changes

![image](https://github.com/uwcsc/codeybot/assets/25677805/8b6fa607-102f-4f6b-825a-f1ccded8b66a)
![image](https://github.com/uwcsc/codeybot/assets/25677805/ef3b5a56-e7f7-4b26-884b-09407ef92000)