### PR TITLE
Counting game

### DIFF
--- a/src/commandDetails/coin/leaderboard.ts
+++ b/src/commandDetails/coin/leaderboard.ts
@@ -25,7 +25,7 @@ const getCoinLeaderboardEmbed = async (
   // Initialize user's coin balance if they have not already
   const userBalance = await getCoinBalanceByUserId(userId);
   let previousBalance = -1;
-  let position = 0;
+  let position = 0; 
   let rank = 0;
   let offset = 0;
   let i = 0;

--- a/src/components/coin.ts
+++ b/src/components/coin.ts
@@ -28,6 +28,7 @@ export enum UserCoinEvent {
   BonusActivity,
   BonusInterviewerList,
   Blackjack,
+  Counting,
   RpsLoss,
   RpsDrawAgainstCodey,
   RpsWin,

--- a/src/events/messageCreate.ts
+++ b/src/events/messageCreate.ts
@@ -14,17 +14,27 @@ import { PDFDocument } from 'pdf-lib';
 import { Logger } from 'winston';
 import { applyBonusByUserId } from '../components/coin';
 import { vars } from '../config';
-import { sendKickEmbed } from '../utils/embeds';
+import { sendKickEmbed, DEFAULT_EMBED_COLOUR } from '../utils/embeds';
 import { convertPdfToPic } from '../utils/pdfToPic';
 import { openDB } from '../components/db';
 import { spawnSync } from 'child_process';
+import { User } from 'discord.js';
+import { getCoinEmoji } from '../components/emojis';
 
 const ANNOUNCEMENTS_CHANNEL_ID: string = vars.ANNOUNCEMENTS_CHANNEL_ID;
 const RESUME_CHANNEL_ID: string = vars.RESUME_CHANNEL_ID;
+const COUNTING_CHANNEL_ID: string = vars.COUNTING_CHANNEL_ID;
 const IRC_USER_ID: string = vars.IRC_USER_ID;
 const PDF_FILE_PATH = 'tmp/resume.pdf';
 const HEIC_FILE_PATH = 'tmp/img.heic';
 const CONVERTED_IMG_PATH = 'tmp/img.jpg';
+
+// Variables and constants associated with the counting game
+const coinsPerMessage: number = 0.1; // Number of coins awarded = coinsPerMessage * highest counting number * messages sent by user
+const countingAuthorDelay: number = 1; // The minimum number of users that must count for someone to go again 
+const previousCountingAuthors: Array<User> = [];
+const authorMessageCounts: Map<User, number> = new Map();
+let currentCountingNumber: number = 1;
 
 /*
  * If honeypot is to exist again, then add HONEYPOT_CHANNEL_ID to the config
@@ -93,13 +103,12 @@ const convertResumePdfsIntoImages = async (
   message: Message,
 ): Promise<Message<boolean> | undefined> => {
   const attachment = message.attachments.first();
-  const hasAttachment = attachment;
   const isPDF = attachment && attachment.contentType === 'application/pdf';
   const isImage =
     attachment && attachment.contentType && attachment.contentType.startsWith('image');
 
   // If no resume pdf is provided, nuke message and DM user about why their message got nuked
-  if (!(hasAttachment && (isPDF || isImage))) {
+  if (!(attachment && (isPDF || isImage))) {
     const user = message.author.id;
     const channel = message.channelId;
 
@@ -200,6 +209,74 @@ const convertResumePdfsIntoImages = async (
   }
 };
 
+const countingGameLogic = async (
+  client: Client,
+  message: Message,
+): Promise<Message<boolean> | undefined> => {
+
+  // Check to see if game should end
+  let reasonForFailure = '';
+  if (isNaN(Number(message.content))) { // Message was not a number
+    reasonForFailure = `"${message.content}" is not a number!`;
+  }
+  else if (previousCountingAuthors.find((author) => author === message.author)) { // Author is still on cooldown
+    reasonForFailure = `<@${message.author.id}> counted too recently!`;
+  }
+  else if (Number(message.content) != currentCountingNumber) { // Wrong number was sent
+    reasonForFailure = `${message.content} is not the next number! The next number was ${currentCountingNumber}.`;
+  }
+
+  if (reasonForFailure) {
+    return endCountingGame(client, message, reasonForFailure);
+  }
+
+  // If checks passed, continue the game
+  currentCountingNumber++;
+  message.react('✅');
+  previousCountingAuthors.unshift(message.author); // Add current author to list of authors on cooldown
+  while (previousCountingAuthors.length > countingAuthorDelay) {
+    previousCountingAuthors.pop(); // Remove last author from cooldown
+  }
+  const currentAuthorCount: number | undefined = authorMessageCounts.get(message.author);
+  authorMessageCounts.set(message.author, currentAuthorCount ? currentAuthorCount + 1 : 1);
+
+  return;
+}
+
+const endCountingGame = async (
+  client: Client,
+  message: Message,
+  reasonForFailure: string
+): Promise<Message<boolean> | undefined> => {
+  const sortedAuthorMessageCounts: Array<[User, number]> = Array.from(authorMessageCounts).sort((a, b) => b[1] - a[1]); // Turns map into descending sorted array
+  const coinsAwarded: Array<string> = ['**Coins awarded:**']; 
+  sortedAuthorMessageCounts.forEach((pair) => {
+    pair[1] *= coinsPerMessage * currentCountingNumber; // Changes number of messages sent to number of coins awarded
+    coinsAwarded.push(`<@${pair[0].id}> - ${pair[1]} ${getCoinEmoji()}`);
+  });
+
+ // ** REMEMBER TO ACTUALLY AWARD COINS
+  
+  const endGameEmbed = new EmbedBuilder()
+  .setColor(DEFAULT_EMBED_COLOUR)
+  .setTitle('Counting Game Over')
+  .setDescription(coinsAwarded.join('\n'));
+  endGameEmbed.addFields([
+    {
+      name: 'Reason for Game Over',
+      value: reasonForFailure,
+    },
+  ]);
+
+  currentCountingNumber = 1;
+  message.react('❌');
+  previousCountingAuthors.length = 0;
+  authorMessageCounts.clear();
+  
+  return await message.channel?.send({embeds: [endGameEmbed]});
+};
+
+
 export const initMessageCreate = async (
   client: Client,
   logger: Logger,
@@ -217,6 +294,10 @@ export const initMessageCreate = async (
   // If channel is in resumes, convert the message attachment to an image
   if (message.channelId === RESUME_CHANNEL_ID) {
     await convertResumePdfsIntoImages(client, message);
+  }
+
+  if (message.channelId === COUNTING_CHANNEL_ID) {
+    await countingGameLogic(client, message);
   }
 
   // Ignore DMs; include announcements, thread, and regular text channels


### PR DESCRIPTION
To fulfill the following request: https://github.com/orgs/uwcsc/projects/2/views/1?filterQuery=counting&pane=issue&itemId=10192321

Added a counting game to codeybot. In this game, users take turns counting higher and higher numbers in a dedicated text channel. The game continues until a user...
1) sends a non-number message
2) sends the wrong number
3) counts too frequently (e.g. counts twice in a row)
The bot will react accordingly to messages and award coins on a game over.

Adjustable variables:
countingAuthorDelay: the number of messages that must be sent before a user can count again
- For instance, if set to 1, a user can only count every other number. If set to 2, a user can only count every third number
coinsPerMessage: the number of coins awarded per message. A game over will reward this many coins to each user:
(coinsPerMessage) * (highest number counted) * (messages sent by user)
coinAwardNumberThreshold: the minimum number that must be counted to award coins.

DEMO:
![image](https://github.com/user-attachments/assets/b6192d83-86fa-44eb-bc79-1858dcc27b4d)
![image](https://github.com/user-attachments/assets/7991028e-691a-41c5-8050-6e4a1172bbff)
