### PR TITLE
Coin prune

### DIFF
--- a/docs/COMMAND-WIKI.md
+++ b/docs/COMMAND-WIKI.md
@@ -14,7 +14,7 @@
 - **Description:** Handle coin functions.
 - **Examples:**<br>`.coin adjust @Codey 100`<br>`.coin adjust @Codey -100 Codey broke.`<br>`.coin`<br>`.coin check @Codey`<br>`.coin c @Codey`<br>`.coin info`<br>`.coin i`<br>`.coin update @Codey 100`<br>`.coin update @Codey 0 Reset Codey's balance.`<br>`.coin transfer @Codey 10`<br>`.coin transfer @Codey 15 Lost a bet to Codey `
 - **Options:** None
-- **Subcommands:** `adjust`, `check`, `info`, `update`, `leaderboard`, `transfer`
+- **Subcommands:** `adjust`, `check`, `info`, `update`, `leaderboard`, `transfer`, `prune`
 
 ## coin adjust
 - **Aliases:** `a`
@@ -46,6 +46,15 @@
 - **Description:** Get the current coin leaderboard.
 - **Examples:**<br>`.coin lb`<br>`.coin leaderboard`
 - **Options:** None
+- **Subcommands:** None
+
+## coin prune
+- **Aliases:** `p`
+- **Description:** Divide every users\
+- **Examples:**<br>`.coin prune @Codey 100`<br>`.coin prune @Codey -100 Codey broke.`
+- **Options:** 
+    - ``divisor``: The number to divide all users\
+    - ``reason``: The reason why we are pruning the balances.
 - **Subcommands:** None
 
 ## coin transfer

--- a/src/commandDetails/coin/leaderboard.ts
+++ b/src/commandDetails/coin/leaderboard.ts
@@ -25,7 +25,7 @@ const getCoinLeaderboardEmbed = async (
   // Initialize user's coin balance if they have not already
   const userBalance = await getCoinBalanceByUserId(userId);
   let previousBalance = -1;
-  let position = 0;
+  let position = 0; 
   let rank = 0;
   let offset = 0;
   let i = 0;

--- a/src/commandDetails/coin/prune.ts
+++ b/src/commandDetails/coin/prune.ts
@@ -1,0 +1,99 @@
+import { CodeyUserError } from './../../codeyUserError';
+import { container } from '@sapphire/framework';
+import { ChatInputCommandInteraction, PermissionsBitField, User} from 'discord.js';
+import {
+  CodeyCommandDetails,
+  CodeyCommandOptionType,
+  SapphireMessageExecuteType,
+  SapphireMessageResponse,
+} from '../../codeyCommand';
+import {
+  updateCoinBalanceByUserId,
+  getCoinBalanceByUserId,
+  UserCoinEvent,
+} from '../../components/coin';
+import { getCoinEmoji } from '../../components/emojis'; 
+import { pluralize } from '../../utils/pluralize';
+
+// Divide everyone's coin counts by given divisor to promote more recent users
+// Designed to be used at the end of a term
+const coinPruneExecuteCommand: SapphireMessageExecuteType = async (
+  client,
+  messageFromUser,
+  args,
+): Promise<SapphireMessageResponse> => {
+  if (
+    !(<Readonly<PermissionsBitField>>messageFromUser.member?.permissions).has(
+      PermissionsBitField.Flags.Administrator,
+    )
+  ) {
+    throw new CodeyUserError(messageFromUser, `You do not have permission to use this command.`);
+  }
+
+  // First and only mandatory argument is divisor
+  const divisor = <number>args['divisor']; // Cast divisor to a number to allow arithmetic operations
+  if (!divisor || divisor < 1) {
+    throw new CodeyUserError(messageFromUser, 'Please enter a valid number to divide by.');
+  }
+
+  // Optional argument is reason
+  const reason = args['reason'];
+
+  if (messageFromUser instanceof ChatInputCommandInteraction) {
+    await (<ChatInputCommandInteraction>messageFromUser).deferReply();
+  }
+  // Prune coin balance of all users
+  const allMembers = await messageFromUser.guild?.members.fetch();
+  if (allMembers) {
+    for (const member of allMembers.values()) {
+      let currentBalance: number = await getCoinBalanceByUserId(member.user.id);
+      await updateCoinBalanceByUserId(
+        member.user.id,
+        <number>Math.round(currentBalance / divisor),
+        UserCoinEvent.AdminCoinPrune,
+        <string>(reason ? reason : ''),
+        client.user?.id,
+      );
+    }
+  }
+  // The message to be displayed after the command has been completed
+  const returnMessage = `Divided all users' coin balances by ${divisor}.`;
+
+  if (messageFromUser instanceof ChatInputCommandInteraction) {
+    await(<ChatInputCommandInteraction>messageFromUser).editReply(
+      returnMessage,
+    );
+  }
+  else {
+    await messageFromUser.channel?.send(returnMessage);
+  }
+  return;
+};
+
+export const coinPruneCommandDetails: CodeyCommandDetails = {
+  name: 'prune',
+  aliases: ['p'],
+  description: 'Divide every users\' coin balance by the passed argument.',
+  detailedDescription: `**Examples:**
+\`${container.botPrefix}coin prune @Codey 100\`
+\`${container.botPrefix}coin prune @Codey -100 Codey broke.\``,
+
+  isCommandResponseEphemeral: false,
+  messageWhenExecutingCommand: 'Pruning...',
+  executeCommand: coinPruneExecuteCommand,
+  options: [
+    {
+      name: 'divisor',
+      description: 'The number to divide all users\' coin balances by.',
+      type: CodeyCommandOptionType.NUMBER,
+      required: true,
+    },
+    {
+      name: 'reason',
+      description: 'The reason why we are pruning the balances.',
+      type: CodeyCommandOptionType.STRING,
+      required: false,
+    },
+  ],
+  subcommandDetails: {},
+};

--- a/src/commandDetails/coin/prune.ts
+++ b/src/commandDetails/coin/prune.ts
@@ -1,6 +1,6 @@
 import { CodeyUserError } from './../../codeyUserError';
 import { container } from '@sapphire/framework';
-import { ChatInputCommandInteraction, PermissionsBitField, User} from 'discord.js';
+import { ChatInputCommandInteraction, PermissionsBitField,} from 'discord.js';
 import {
   CodeyCommandDetails,
   CodeyCommandOptionType,
@@ -12,10 +12,8 @@ import {
   getCoinBalanceByUserId,
   UserCoinEvent,
 } from '../../components/coin';
-import { getCoinEmoji } from '../../components/emojis'; 
-import { pluralize } from '../../utils/pluralize';
 
-// Divide everyone's coin counts by given divisor to promote more recent users
+// Divide everyone's coin counts by given divisor to ensure the leaderboard is populated with more active members
 // Designed to be used at the end of a term
 const coinPruneExecuteCommand: SapphireMessageExecuteType = async (
   client,
@@ -32,7 +30,7 @@ const coinPruneExecuteCommand: SapphireMessageExecuteType = async (
 
   // First and only mandatory argument is divisor
   const divisor = <number>args['divisor']; // Cast divisor to a number to allow arithmetic operations
-  if (!divisor || divisor < 1) {
+  if (!divisor || divisor <= 1) {
     throw new CodeyUserError(messageFromUser, 'Please enter a valid number to divide by.');
   }
 

--- a/src/commands/coin/coin.ts
+++ b/src/commands/coin/coin.ts
@@ -6,6 +6,7 @@ import { coinInfoCommandDetails } from '../../commandDetails/coin/info';
 import { coinLeaderboardCommandDetails } from '../../commandDetails/coin/leaderboard';
 import { coinTransferCommandDetails } from '../../commandDetails/coin/transfer';
 import { coinUpdateCommandDetails } from '../../commandDetails/coin/update';
+import { coinPruneCommandDetails } from '../../commandDetails/coin/prune';
 
 const coinCommandDetails: CodeyCommandDetails = {
   name: 'coin',
@@ -31,6 +32,7 @@ const coinCommandDetails: CodeyCommandDetails = {
     update: coinUpdateCommandDetails,
     leaderboard: coinLeaderboardCommandDetails,
     transfer: coinTransferCommandDetails,
+    prune: coinPruneCommandDetails
   },
   defaultSubcommandDetails: coinCheckCommandDetails,
 };

--- a/src/components/coin.ts
+++ b/src/components/coin.ts
@@ -23,6 +23,7 @@ export enum BonusType {
 
 export enum UserCoinEvent {
   AdminCoinAdjust,
+  AdminCoinPrune,
   AdminCoinUpdate,
   BonusDaily,
   BonusActivity,


### PR DESCRIPTION
Completed: https://github.com/orgs/uwcsc/projects/2/views/1?itemId=28393973&pane=issue

Added command, /coin prune <divisor>, to divide every users' coin balance by <divisor>
This was designed to be used at the end of each term to populate the leaderboards with more active users

![image](https://github.com/user-attachments/assets/cb68207b-3289-4660-8f3c-6536dcbed672)
![image](https://github.com/user-attachments/assets/22ff9bfe-f0a0-4061-8834-2eb7c5ed3c44)
